### PR TITLE
[REF] CI: Rename tox check to build

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -38,11 +38,11 @@ jobs:
             python_arch: 'x64'
             tox_env: 'py39-cover,codecov'
             os: 'ubuntu-latest'
-          - name: 'py310-cover (ubuntu) + pypi release'
+          - name: 'py310-cover (ubuntu) + build'
             python: '3.10'
             toxpython: 'python3.10'
             python_arch: 'x64'
-            tox_env: 'py310-cover,codecov'
+            tox_env: 'py310-cover,codecov,build'
             os: 'ubuntu-latest'
 
           # windows
@@ -128,13 +128,9 @@ jobs:
         TOXPYTHON: '${{ matrix.toxpython }}'
       run: |
         tox -e ${{ matrix.tox_env }} -v
-    - name: Build a binary wheel and a source tarball
-      if: runner.os == 'Linux' && startsWith(matrix.tox_env, 'py39-cover')
-      run: >-
-        tox -e check -v
     # TODO: Publish package only for signed tags
     - name: Publish package
-      if: github.event_name == 'push' && startsWith(github.ref, 'refs/tags') && runner.os == 'Linux' && startsWith(matrix.tox_env, 'py310-cover')
+      if: github.event_name == 'push' && startsWith(github.ref, 'refs/tags') && contains(matrix.tox_env, 'build')
       run: |
         python -m twine upload --verbose -u __token__ -p ${{ secrets.PYPI_API_TOKEN }} --repository-url https://upload.pypi.org/legacy/ dist/*
     # TODO: Add GITHUB_RUN_ID.GITHUB_RUN_ATTEMPT.GITHUB_RUN_NUMBER to bumpversion to avoid duplicating upload versions or even the git sha

--- a/tox.ini
+++ b/tox.ini
@@ -1,7 +1,7 @@
 [tox]
 envlist =
     clean,
-    check,
+    build,
     py37-cover,
     py37-nocov,
     py38-cover,
@@ -18,7 +18,7 @@ envlist =
 
 [testenv]
 basepython =
-    {clean,check,report,codecov}: {env:TOXPYTHON:python3}
+    {clean,build,report,codecov}: {env:TOXPYTHON:python3}
 setenv =
     PYTHONPATH={toxinidir}/tests
     PYTHONUNBUFFERED=yes
@@ -28,7 +28,7 @@ deps = -r{toxinidir}/test-requirements.txt
 commands =
     {posargs:pytest -s -vv --ignore=src}
 
-[testenv:check]
+[testenv:build]
 skip_install = true
 commands =
     python -m build --sdist --wheel --outdir {toxinidir}/dist_wo_pbr/


### PR DESCRIPTION
It builds the package and check but it is better naming build