### PR TITLE
[REF] oca_pre_commit_hooks: Small improvements

### DIFF
--- a/.bumpversion.cfg
+++ b/.bumpversion.cfg
@@ -16,6 +16,10 @@ replace = /v{new_version}.svg
 search = /v{current_version}...main
 replace = /v{new_version}...main
 
+[bumpversion:file:README.md]
+search = rev: v{current_version}
+replace = rev: v{new_version}
+
 [bumpversion:file:src/oca_pre_commit_hooks/__init__.py]
 search = __version__ = "{current_version}"
 replace = __version__ = "{new_version}"

--- a/README.md
+++ b/README.md
@@ -19,9 +19,11 @@ OCA's custom pre-commit hooks for Odoo modules
 
 You don't need to install it directly only configure your ".pre-commit-config.yaml" file
 
-Even you can install using github directly
-
-    pip install -U git+https://github.com/OCA/odoo-pre-commit-hooks.git@main
+You even can install it directly:
+ - Installing from pypi:
+   - pip install -U odoo-pre-commit-hooks
+ - Installing from github:
+   - pip install --force-reinstall -U git+https://github.com/OCA/odoo-pre-commit-hooks.git@main
 
 
 # Usage pre-commit-config.yaml
@@ -30,19 +32,115 @@ Add to your ".pre-commit-config.yaml" configuration file the following input
 
 
 ```yaml
-
     - repo: https://github.com/OCA/odoo-pre-commit-hooks
-        rev: main  # Change to last version or git sha
+        rev: v0.0.4
         hooks:
-        - id: oca-checks-odoo-module-local
-
+        - id: oca-checks-odoo-module
 ```
 
 # Usage using directly the entry points
 
-If you install directly the package from github you can use the entry points:
+If you install directly the package use the entry point:
 
-    * HOOK-APP (TODO ADD ALL HOOKS HERE)
+    oca-checks-odoo-module --help
+
+
+[//]: # (start-checks)
+# Checks
+
+* Check manifest_syntax_error
+        Check if the manifest file has syntax error
+
+* Check missing_readme
+        Check if a README file is missing
+
+* Check csv_duplicate_record_id
+        duplicate CSV "id" AKA xmlid but for CSV files
+
+* Check csv_syntax_error
+        Check syntax error for CSV files declared in the manifest
+
+* Check po_requires_module
+        Translation entry requires comment '#. module: MODULE'
+
+* Check po_python_parse_printf
+        Check if 'msgid' is using 'str' variables like '%s'
+        So translation 'msgstr' must be the same number of variables too
+
+* Check po_python_parse_format
+        Check if 'msgid' is using 'str' variables like '{}'
+        So translation 'msgstr' must be the same number of variables too
+
+* Check po_duplicate_message_definition (message-id)
+        in all entries of PO files
+
+        We are not using `check_for_duplicates` parameter of polib.pofile method
+            e.g. polib.pofile(..., check_for_duplicates=True)
+        Because the output is:
+            raise ValueError('Entry "%s" already exists' % entry.msgid)
+        It doesn't show the number of lines duplicated
+        and it shows the entire string of the message_id without truncating it
+        or replacing newlines
+
+* Check po_syntax_error
+        Check syntax of PO files from i18n* folders
+
+* Check xml_redundant_module_name
+
+        If the module is called "module_a" and the xmlid is
+        <record id="module_a.xmlid_name1" ...
+
+        The "module_a." is redundant it could be replaced to only
+        <record id="xmlid_name1" ...
+
+* Check xml_dangerous_filter_wo_user
+        Check dangerous filter without a user assigned.
+
+* Check xml_create_user_wo_reset_password
+        records of user without context="{'no_reset_password': True}"
+        This context avoid send email and mail log warning
+
+* Check xml_view_dangerous_replace_low_priority in ir.ui.view
+
+            <field name="priority" eval="10"/>
+            ...
+                <field name="name" position="replace"/>
+
+* Check xml_deprecated_tree_attribute
+          The tree-view declaration is using a deprecated attribute.
+
+* Check xml_dangerous_qweb_replace_low_priority
+        Dangerous qweb view defined with low priority
+
+* Check xml_deprecated_data_node
+        Deprecated <data> node inside <odoo> xml node
+
+* Check xml_deprecated_openerp_xml_node
+        deprecated <openerp> xml node
+
+* Check xml_deprecated_qweb_directive
+        for use of deprecated QWeb directives t-*-options
+
+* Check xml_not_valid_char_link
+        The resource in in src/href contains a not valid character.
+
+* Check xml_duplicate_record_id
+
+        If a module has duplicated record_id AKA xml_ids
+        file1.xml
+            <record id="xmlid_name1"
+        file2.xml
+            <record id="xmlid_name1"
+
+* Check xml_duplicate_fields in all record nodes
+            <record id="xmlid_name1"...
+                <field name="field_name1"...
+                <field name="field_name1"...
+
+* Check xml_syntax_error
+        Check syntax of XML files declared in the Odoo manifest
+
+[//]: # (end-checks)
 
 
 ## Licenses

--- a/setup.py
+++ b/setup.py
@@ -70,7 +70,6 @@ setup(
         "Operating System :: Microsoft :: Windows",
         "Operating System :: MacOS",
         "Programming Language :: Python :: 3",
-        "Programming Language :: Python :: 3.6",
         "Programming Language :: Python :: 3.7",
         "Programming Language :: Python :: 3.8",
         "Programming Language :: Python :: 3.9",

--- a/src/oca_pre_commit_hooks/checks_odoo_module.py
+++ b/src/oca_pre_commit_hooks/checks_odoo_module.py
@@ -89,6 +89,9 @@ class ChecksOdooModule:
 
     @utils.only_required_for_checks("manifest_syntax_error")
     def check_manifest(self):
+        """* Check manifest_syntax_error
+        Check if the manifest file has syntax error
+        """
         if not self.manifest_dict:
             self.checks_errors["manifest_syntax_error"].append(
                 f"{self.manifest_path} could not be loaded {self.error}"
@@ -97,6 +100,8 @@ class ChecksOdooModule:
     @utils.only_required_for_installable()
     @utils.only_required_for_checks("missing_readme")
     def check_missing_readme(self):
+        """* Check missing_readme
+        Check if a README file is missing"""
         for readme_name in DFTL_README_FILES:
             readme_path = os.path.join(self.odoo_addon_path, readme_name)
             if os.path.isfile(readme_path):
@@ -121,7 +126,6 @@ class ChecksOdooModule:
     def check_csv(self):
         manifest_datas = self.manifest_referenced_files[".csv"]
         if not manifest_datas:  # pragma: no cover
-            # TODO: Add a module without csv files
             return
         checks_obj = checks_odoo_module_csv.ChecksOdooModuleCSV(
             manifest_datas, self.odoo_addon_name, self.enable, self.disable

--- a/src/oca_pre_commit_hooks/checks_odoo_module_csv.py
+++ b/src/oca_pre_commit_hooks/checks_odoo_module_csv.py
@@ -22,8 +22,11 @@ class ChecksOdooModuleCSV:
 
     @utils.only_required_for_checks("csv_syntax_error", "csv_duplicate_record_id")
     def check_csv(self):
-        """*Check csv_duplicate_record_id
+        """* Check csv_duplicate_record_id
         duplicate CSV "id" AKA xmlid but for CSV files
+
+        * Check csv_syntax_error
+        Check syntax error for CSV files declared in the manifest
         """
         csvids = defaultdict(list)
         for manifest_data in self.manifest_datas:

--- a/src/oca_pre_commit_hooks/checks_odoo_module_po.py
+++ b/src/oca_pre_commit_hooks/checks_odoo_module_po.py
@@ -54,15 +54,22 @@ class ChecksOdooModulePO:
                     }
                 )
             except OSError as po_err:  # pragma: no cover
-                # TODO: Raises check_po_syntax_error
                 manifest_data.update(
                     {
                         "po": None,
                         "file_error": po_err,
                     }
                 )
-                msg = str(po_err).replace(f'{manifest_data["filename"]} ', "").strip()
-                self.checks_errors["po_syntax_error"].append(f'{manifest_data["filename"]} {msg}')
+
+    @utils.only_required_for_checks("po_syntax_error")
+    def check_po_syntax_error(self):
+        """* Check po_syntax_error
+        Check syntax of PO files from i18n* folders"""
+        for manifest_data in self.manifest_datas:
+            if not manifest_data["file_error"]:
+                continue
+            msg = str(manifest_data["file_error"]).replace(f'{manifest_data["filename"]} ', "").strip()
+            self.checks_errors["po_syntax_error"].append(f'{manifest_data["filename"]} {msg}')
 
     @staticmethod
     def parse_printf(main_str, secondary_str):
@@ -193,8 +200,12 @@ class ChecksOdooModulePO:
         """* Check po_requires_module
         Translation entry requires comment '#. module: MODULE'
 
-        * Check po_python_parse_printf and po_python_parse_format
-        Check if 'msgid' is using 'str' variables like '%s' or '{}'
+        * Check po_python_parse_printf
+        Check if 'msgid' is using 'str' variables like '%s'
+        So translation 'msgstr' must be the same number of variables too
+
+        * Check po_python_parse_format
+        Check if 'msgid' is using 'str' variables like '{}'
         So translation 'msgstr' must be the same number of variables too
         """
         # po_requires_module

--- a/src/oca_pre_commit_hooks/checks_odoo_module_xml.py
+++ b/src/oca_pre_commit_hooks/checks_odoo_module_xml.py
@@ -33,7 +33,6 @@ class ChecksOdooModuleXML:
                         "file_error": xml_err,
                     }
                 )
-                self.checks_errors["xml_syntax_error"].append(f'{manifest_data["filename"]} {xml_err}')
 
     @staticmethod
     def _get_priority(view):
@@ -117,6 +116,15 @@ class ChecksOdooModuleXML:
                 f"{fields[0][0]['filename']}:{fields[0][1].sourceline} "
                 f'Duplicate xml field "{field_key[0]}" in lines {lines_str}'
             )
+
+    @utils.only_required_for_checks("xml_syntax_error")
+    def check_xml_syntax_error(self):
+        """* Check xml_syntax_error
+        Check syntax of XML files declared in the Odoo manifest"""
+        for manifest_data in self.manifest_datas:
+            if not manifest_data["file_error"]:
+                continue
+            self.checks_errors["xml_syntax_error"].append(f'{manifest_data["filename"]} {manifest_data["file_error"]}')
 
     @utils.only_required_for_checks("xml_redundant_module_name")
     def visit_xml_record(self, manifest_data, record):
@@ -209,7 +217,8 @@ class ChecksOdooModuleXML:
 
     @utils.only_required_for_checks("xml_not_valid_char_link")
     def check_xml_not_valid_char_link(self):
-        """The resource in in src/href contains a not valid character"""
+        """* Check xml_not_valid_char_link
+        The resource in in src/href contains a not valid character."""
         for manifest_data in self.manifest_datas:
             for name, attr in (("link", "href"), ("script", "src")):
                 nodes = manifest_data["node"].xpath(f".//{name}[@{attr}]")
@@ -224,7 +233,8 @@ class ChecksOdooModuleXML:
 
     @utils.only_required_for_checks("xml_dangerous_qweb_replace_low_priority")
     def check_xml_dangerous_qweb_replace_low_priority(self):
-        """Check dangerous qweb view defined with low priority"""
+        """* Check xml_dangerous_qweb_replace_low_priority
+        Dangerous qweb view defined with low priority"""
         for manifest_data in self.manifest_datas:
             for template in manifest_data["node"].xpath("/odoo//template|/openerp//template"):
                 try:
@@ -242,7 +252,8 @@ class ChecksOdooModuleXML:
 
     @utils.only_required_for_checks("xml_deprecated_data_node")
     def check_xml_deprecated_data_node(self):
-        """Check deprecated <data> node inside <odoo> xml node"""
+        """* Check xml_deprecated_data_node
+        Deprecated <data> node inside <odoo> xml node"""
         for manifest_data in self.manifest_datas:
             for odoo_node in manifest_data["node"].xpath("/odoo|/openerp"):
                 children_count = 0
@@ -262,7 +273,8 @@ class ChecksOdooModuleXML:
 
     @utils.only_required_for_checks("xml_deprecated_openerp_xml_node")
     def check_xml_deprecated_openerp_node(self):
-        """Check deprecated <openerp> xml node"""
+        """* Check xml_deprecated_openerp_xml_node
+        deprecated <openerp> xml node"""
         for manifest_data in self.manifest_datas:
             for openerp_node in manifest_data["node"].xpath("/openerp"):
                 # TODO: Add autofix option
@@ -272,7 +284,8 @@ class ChecksOdooModuleXML:
 
     @utils.only_required_for_checks("xml_deprecated_qweb_directive")
     def check_xml_deprecated_qweb_directive(self):
-        """Check for use of deprecated QWeb directives t-*-options"""
+        """* Check xml_deprecated_qweb_directive
+        for use of deprecated QWeb directives t-*-options"""
         deprecated_directives = {
             "t-esc-options",
             "t-field-options",

--- a/src/oca_pre_commit_hooks/cli.py
+++ b/src/oca_pre_commit_hooks/cli.py
@@ -56,7 +56,7 @@ def main(argv=None):
         type=parse_disable,
         default=set(),
         help=(
-            "Enable the checker with the given 'check_name' (snake_case), separated by commas."
+            "Enable the checker with the given 'check_name' (snake_case), separated by commas. "
             "Default: All checks are enabled by default"
         ),
     )

--- a/tox.ini
+++ b/tox.ini
@@ -19,7 +19,7 @@ envlist =
 
 [testenv]
 basepython =
-    {clean,build,report,codecov,lint}: {env:TOXPYTHON:python3}
+    {clean,build,report,codecov,lint,update-readme}: {env:TOXPYTHON:python3}
 setenv =
     PYTHONPATH={toxinidir}/tests
     PYTHONUNBUFFERED=yes
@@ -29,6 +29,15 @@ deps = -r{toxinidir}/test-requirements.txt
 commands =
     {posargs:pytest -s -vv --ignore=src}
 
+[testenv:update-readme]
+setenv =
+    {[testenv]setenv}
+    BUILD_README=true
+usedevelop = true
+commands =
+    {posargs:pytest -svvk test_build_docstring}
+deps =
+    {[testenv]deps}
 
 [testenv:lint]
 skip_install = true


### PR DESCRIPTION
* Fix typos
* bump2version: Consider the revision of latest hook version in the README
* README: Small changes
* Remove py3.6 as compatible to match with pre-commit dependency
* Add docstring to checks methods
* Use current path of the file of tests and use os.path.join to avoid mutabling
* Add script to auto generage documentation in README file