### PR TITLE
[FIX] oca_pre_commit_hooks: Fix checks if it has syntax error

### DIFF
--- a/src/oca_pre_commit_hooks/checks_odoo_module_csv.py
+++ b/src/oca_pre_commit_hooks/checks_odoo_module_csv.py
@@ -45,7 +45,7 @@ class ChecksOdooModuleCSV:
                                 manifest_data["model"],
                             )
                         )
-            except (FileNotFoundError, csv.Error) as csv_err:  # pragma: no cover
+            except (FileNotFoundError, csv.Error, UnicodeDecodeError) as csv_err:
                 self.checks_errors["csv_syntax_error"].append(f'{manifest_data["filename"]} {csv_err}')
         for csvid, records in csvids.items():
             if len(records) < 2:

--- a/src/oca_pre_commit_hooks/checks_odoo_module_po.py
+++ b/src/oca_pre_commit_hooks/checks_odoo_module_po.py
@@ -46,17 +46,25 @@ class ChecksOdooModulePO:
         self.checks_errors = defaultdict(list)
         for manifest_data in manifest_datas:
             try:
-                polib_file = polib.pofile(manifest_data["filename"])
+                with open(manifest_data["filename"], "rt", encoding="UTF-8") as filename_obj:
+                    # Do not use polib.pofile(manifest_data["filename"])
+                    # because raise the following error for PO files with syntax error:
+                    # pytest.PytestUnraisableExceptionWarning: Exception ignored in: <_io.FileIO [closed]>
+                    # Traceback (most recent call last):
+                    #     File "../polib.py", line 1474, in add
+                    #     action = getattr(self, 'handle_%s' % next_state)
+                    # ResourceWarning: unclosed file <_io.FileIO name='..' mode='rb' closefd=True>
+                    polib_entries = polib.pofile(filename_obj.read())
                 manifest_data.update(
                     {
-                        "po": polib_file,
+                        "po": polib_entries,
                         "file_error": None,
                     }
                 )
-            except OSError as po_err:  # pragma: no cover
+            except (OSError, UnicodeDecodeError) as po_err:
                 manifest_data.update(
                     {
-                        "po": None,
+                        "po": [],
                         "file_error": po_err,
                     }
                 )

--- a/src/oca_pre_commit_hooks/checks_odoo_module_xml.py
+++ b/src/oca_pre_commit_hooks/checks_odoo_module_xml.py
@@ -26,7 +26,7 @@ class ChecksOdooModuleXML:
                             "file_error": None,
                         }
                     )
-            except (FileNotFoundError, etree.XMLSyntaxError) as xml_err:  # pragma: no cover
+            except (FileNotFoundError, etree.XMLSyntaxError, UnicodeDecodeError) as xml_err:
                 manifest_data.update(
                     {
                         "node": etree.Element("__empty__"),

--- a/src/oca_pre_commit_hooks/utils.py
+++ b/src/oca_pre_commit_hooks/utils.py
@@ -32,8 +32,7 @@ def getattr_checks(obj_or_class, enable=None, disable=None, prefix="check_"):
     """Get all the attributes callables (methods)
     that start with word 'def check_*'
     Skip the methods with attribute "checks" defined if
-    the check is not enable or if it is disabled
-    """
+    the check is not enable or if it is disabled"""
     for attr in dir(obj_or_class):
         if not callable(getattr(obj_or_class, attr)) or not attr.startswith(prefix):
             continue

--- a/test_repo/syntax_err_module/__manifest__.py
+++ b/test_repo/syntax_err_module/__manifest__.py
@@ -1,0 +1,9 @@
+{
+    'name': 'Syntax error module',
+    'version': '16.0.1.0.0',
+    'website': 'https://odoo-community.org',
+    'depends': ['base'],
+    'data': [
+        'ir.model.access.csv',
+    ],
+}

--- a/test_repo/syntax_err_module/i18n/es.po
+++ b/test_repo/syntax_err_module/i18n/es.po
@@ -1,0 +1,19 @@
+msgid ""
+msgstr ""
+"Project-Id-Version: Odoo Server\n"
+"Report-Msgid-Bugs-To: \n"
+"POT-Creation-Date: 1985-04-14 17:12+0000\n"
+"PO-Revision-Date: 1985-04-14 02:03+0000\n"
+"Last-Translator: Moisés López <moylop260@vauxoo.com>\n"
+"Language-Team: \n"
+"MIME-Version: 1.0\n"
+"Content-Type: text/plain; charset=UTF-8\n"
+"Content-Transfer-Encoding: \n"
+"Plural-Forms: \n"
+
+#. module: broken_module
+#: model:ir.model.fields,field_description:broken_module.field_wizard_description
+#, python-format
+msgid "Branch"
+msgstr "syntax
+error"

--- a/test_repo/syntax_err_module/ir.model.access.csv
+++ b/test_repo/syntax_err_module/ir.model.access.csv
@@ -1,0 +1,2 @@
+id,name,,,,,,hello
+1,Mois???s L???pez,other,,,,ñ,

--- a/tests/test_checks.py
+++ b/tests/test_checks.py
@@ -18,12 +18,14 @@ ALL_CHECK_CLASS = [
 
 EXPECTED_ERRORS = {
     "csv_duplicate_record_id": 1,
+    "csv_syntax_error": 1,
     "manifest_syntax_error": 2,
-    "missing_readme": 1,
+    "missing_readme": 2,
     "po_duplicate_message_definition": 3,
     "po_python_parse_format": 4,
     "po_python_parse_printf": 2,
     "po_requires_module": 1,
+    "po_syntax_error": 1,
     "xml_create_user_wo_reset_password": 1,
     "xml_dangerous_filter_wo_user": 1,
     "xml_dangerous_qweb_replace_low_priority": 3,
@@ -76,9 +78,16 @@ class TestChecks(unittest.TestCase):
                 check_errors_count[check] += len(errors)
         return check_errors_count
 
+    def assertDictEqual(self, d1, d2, msg=None):
+        """Original method does not show the correct item diff
+        Using ordered list it is showing the diff better"""
+        real_dict2list = [(i, d1[i]) for i in sorted(d1)]
+        expected_dict2list = [(i, d2[i]) for i in sorted(d2)]
+        self.assertEqual(real_dict2list, expected_dict2list, msg)
+
     def test_checks(self):
         all_check_errors = oca_pre_commit_hooks.checks_odoo_module.run(
-            self.manifest_paths, no_exit=True, no_verbose=True
+            self.manifest_paths, no_exit=True, no_verbose=False
         )
         real_errors = self.get_count_code_errors(all_check_errors)
         # Uncommet to get sorted values to update EXPECTED_ERRORS dict


### PR DESCRIPTION
* PO fix the following error:
```python
pytest.PytestUnraisableExceptionWarning: Exception ignored in: <_io.FileIO [closed]>
Traceback (most recent call last):
    File "../polib.py", line 1474, in add
    action = getattr(self, 'handle_%s' % next_state)
ResourceWarning: unclosed file <_io.FileIO name='..' mode='rb' closefd=True>
```

* CSV

Add a syntax error CSV file

* ALL

Consider UnicodeDecodeError reading files