### PR TITLE
[REF] checks_odoo_module_xml: Allow duplicated fields with 'groups'

### DIFF
--- a/README.md
+++ b/README.md
@@ -274,7 +274,7 @@ options:
  * xml-duplicate-fields
 
     - https://github.com/OCA/odoo-pre-commit-hooks/blob/v0.0.11/test_repo/broken_module/model_view_odoo2.xml#L132 Duplicate xml field "name" in lines 133
-    - https://github.com/OCA/odoo-pre-commit-hooks/blob/v0.0.11/test_repo/broken_module/model_view_odoo2.xml#L138 Duplicate xml field "name" in lines 139
+    - https://github.com/OCA/odoo-pre-commit-hooks/blob/v0.0.11/test_repo/broken_module/model_view_odoo2.xml#L141 Duplicate xml field "name" in lines 142
     - https://github.com/OCA/odoo-pre-commit-hooks/blob/v0.0.11/test_repo/broken_module/model_view_odoo2.xml#L41 Duplicate xml field "key_config" in lines 42
     - https://github.com/OCA/odoo-pre-commit-hooks/blob/v0.0.11/test_repo/broken_module/model_view_odoo2.xml#L6 Duplicate xml field "name" in lines 13
     - https://github.com/OCA/odoo-pre-commit-hooks/blob/v0.0.11/test_repo/broken_module/model_view_odoo2.xml#L73 Duplicate xml field "arch" in lines 76

--- a/src/oca_pre_commit_hooks/checks_odoo_module_xml.py
+++ b/src/oca_pre_commit_hooks/checks_odoo_module_xml.py
@@ -90,6 +90,7 @@ class ChecksOdooModuleXML:
                             field.get("name"),
                             field.get("context"),
                             field.get("filter_domain"),
+                            field.get("groups"),
                             field.getparent(),
                         )
                         xml_fields[field_key].append((manifest_data, field))

--- a/test_repo/broken_module/model_view_odoo2.xml
+++ b/test_repo/broken_module/model_view_odoo2.xml
@@ -131,6 +131,9 @@
                         <tree>
                             <field name="name"/>
                             <field name="name"/>
+
+                            <field name="company_id" invisible="1"/>
+                            <field name="company_id" groups="base.group_multi_company"/>
                         </tree>
                     </field>
                     <field name="value_ids">

--- a/tox.ini
+++ b/tox.ini
@@ -16,7 +16,7 @@ setenv =
     PYTHONPATH={toxinidir}/tests
     PYTHONUNBUFFERED=yes
     # Compatible with "tox --parallel" to avoid concurrency
-    # COVERAGE_FILE={toxinidir}/.coverage_{envname}
+    COVERAGE_FILE={toxinidir}/.coverage.{envname}
     COVERAGE_CONTEXT={envname}
 passenv =
     *


### PR DESCRIPTION
Related to https://github.com/odoo/odoo/pull/103743
Fix https://github.com/OCA/odoo-pre-commit-hooks/issues/10
