### PR TITLE
[REF] oca_pre_commit_hooks: Separate files cli and cli_po to run it directly

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -1,4 +1,4 @@
-#!/usr/bin/env python
+#!/usr/bin/env python3
 
 import re
 from glob import glob
@@ -91,7 +91,7 @@ setup(
     entry_points={
         "console_scripts": [
             "oca-checks-odoo-module = oca_pre_commit_hooks.cli:main",
-            "oca-checks-po = oca_pre_commit_hooks.cli:main_po",
+            "oca-checks-po = oca_pre_commit_hooks.cli_po:main",
         ]
     },
 )

--- a/src/oca_pre_commit_hooks/cli.py
+++ b/src/oca_pre_commit_hooks/cli.py
@@ -1,3 +1,4 @@
+#!/usr/bin/env python3
 """Module that contains the command line app.
 Why does this file exist, and why not put this in __main__?
   You might be tempted to import things from __main__ later, but that will cause
@@ -13,7 +14,7 @@ Why does this file exist, and why not put this in __main__?
 import argparse
 import sys
 
-from oca_pre_commit_hooks import checks_odoo_module, checks_odoo_module_po
+from oca_pre_commit_hooks import checks_odoo_module
 
 
 def parse_disable(value):
@@ -68,14 +69,5 @@ def main(argv=None):
     return checks_odoo_module.main(**kwargs)
 
 
-def main_po(argv=None):
-    parser = global_parser()
-    parser.add_argument(
-        "po_files",
-        nargs="*",
-        help="PO files.",
-    )
-    if argv is None:
-        argv = sys.argv[1:]
-    kwargs = vars(parser.parse_args(argv))
-    return checks_odoo_module_po.main(**kwargs)
+if __name__ == "__main__":
+    main()

--- a/src/oca_pre_commit_hooks/cli_po.py
+++ b/src/oca_pre_commit_hooks/cli_po.py
@@ -1,0 +1,32 @@
+#!/usr/bin/env python3
+"""Module that contains the command line app.
+Why does this file exist, and why not put this in __main__?
+  You might be tempted to import things from __main__ later, but that will cause
+  problems: the code will get executed twice:
+  - When you run `python -mpre_commit_vauxoo` python will execute
+    ``__main__.py`` as a script. That means there won't be any
+    ``pre_commit_vauxoo.__main__`` in ``sys.modules``.
+  - When you import __main__ it will get executed again (as a module) because
+    there's no ``pre_commit_vauxoo.__main__`` in ``sys.modules``.
+  Also see (1) from http://click.pocoo.org/5/setuptools/#setuptools-integration
+"""
+import sys
+
+from oca_pre_commit_hooks import checks_odoo_module_po, cli
+
+
+def main(argv=None):
+    parser = cli.global_parser()
+    parser.add_argument(
+        "po_files",
+        nargs="*",
+        help="PO files.",
+    )
+    if argv is None:
+        argv = sys.argv[1:]
+    kwargs = vars(parser.parse_args(argv))
+    return checks_odoo_module_po.main(**kwargs)
+
+
+if __name__ == "__main__":
+    main()

--- a/tests/test_checks_po.py
+++ b/tests/test_checks_po.py
@@ -37,7 +37,7 @@ class TestChecksPO(common.ChecksCommon):
         super().setUp()
         self.expected_errors = EXPECTED_ERRORS.copy()
         self.checks_run = oca_pre_commit_hooks.checks_odoo_module_po.run
-        self.checks_cli_main = oca_pre_commit_hooks.cli.main_po
+        self.checks_cli_main = oca_pre_commit_hooks.cli_po.main
 
     def test_non_exists_path(self):
         all_check_errors = self.checks_run(["/tmp/no_exists"], no_exit=True, no_verbose=False)


### PR DESCRIPTION
Able to run:
 - `src/oca_pre_commit_hooks/cli_po.py --help`
 - `src/oca_pre_commit_hooks/cli.py --help`