### PR TITLE
Draft: [IMP] oca_pre_commit_hooks: Support for config file (#37)

### DIFF
--- a/README.md
+++ b/README.md
@@ -186,6 +186,7 @@ It disable the entire file
 ```bash
 usage: oca-checks-odoo-module [-h] [--no-verbose] [--no-exit]
                               [--disable DISABLE] [--enable ENABLE]
+                              [--config CONFIG]
                               [files_or_modules ...]
 
 positional arguments:
@@ -202,6 +203,8 @@ options:
                         Enable the checker with the given 'check-name',
                         separated by commas. Default: All checks are enabled
                         by default
+  --config CONFIG, -c CONFIG
+                        Path to a configuration file
 
 ```
 
@@ -213,7 +216,7 @@ options:
 # Help PO
 ```bash
 usage: oca-checks-po [-h] [--no-verbose] [--no-exit] [--disable DISABLE]
-                     [--enable ENABLE]
+                     [--enable ENABLE] [--config CONFIG]
                      [po_files ...]
 
 positional arguments:
@@ -230,6 +233,8 @@ options:
                         Enable the checker with the given 'check-name',
                         separated by commas. Default: All checks are enabled
                         by default
+  --config CONFIG, -c CONFIG
+                        Path to a configuration file
 
 ```
 

--- a/src/oca_pre_commit_hooks/cli.py
+++ b/src/oca_pre_commit_hooks/cli.py
@@ -11,52 +11,14 @@ Why does this file exist, and why not put this in __main__?
   Also see (1) from http://click.pocoo.org/5/setuptools/#setuptools-integration
 """
 
-import argparse
 import sys
 
 from oca_pre_commit_hooks import checks_odoo_module
-
-
-def parse_disable(value):
-    return set(value.split(","))
-
-
-def global_parser():
-    parser = argparse.ArgumentParser()
-    parser.add_argument(
-        "--no-verbose",
-        action="store_true",
-        default=False,
-        help="If enabled so disable verbose mode.",
-    )
-    parser.add_argument(
-        "--no-exit",
-        action="store_true",
-        default=False,
-        help="If enabled so it will not call exit.",
-    )
-    parser.add_argument(
-        "--disable",
-        "-d",
-        type=parse_disable,
-        default=set(),
-        help="Disable the checker with the given 'check-name', separated by commas.",
-    )
-    parser.add_argument(
-        "--enable",
-        "-e",
-        type=parse_disable,
-        default=set(),
-        help=(
-            "Enable the checker with the given 'check-name', separated by commas. "
-            "Default: All checks are enabled by default"
-        ),
-    )
-    return parser
+from oca_pre_commit_hooks.global_parser import GlobalParser
 
 
 def main(argv=None):
-    parser = global_parser()
+    parser = GlobalParser()
     parser.add_argument(
         "files_or_modules",
         nargs="*",

--- a/src/oca_pre_commit_hooks/cli_po.py
+++ b/src/oca_pre_commit_hooks/cli_po.py
@@ -12,11 +12,12 @@ Why does this file exist, and why not put this in __main__?
 """
 import sys
 
-from oca_pre_commit_hooks import checks_odoo_module_po, cli
+from oca_pre_commit_hooks import checks_odoo_module_po
+from oca_pre_commit_hooks.global_parser import GlobalParser
 
 
 def main(argv=None):
-    parser = cli.global_parser()
+    parser = GlobalParser()
     parser.add_argument(
         "po_files",
         nargs="*",

--- a/src/oca_pre_commit_hooks/global_parser.py
+++ b/src/oca_pre_commit_hooks/global_parser.py
@@ -56,9 +56,11 @@ class GlobalParser(argparse.ArgumentParser):
 
         if not res.config:
             if isfile(join(getcwd(), CONFIG_NAME)):
-                res.config = join(getcwd(), CONFIG_NAME)
+                res.config = open(join(getcwd(), CONFIG_NAME), encoding="UTF-8")  # pylint:disable=consider-using-with
             elif isfile(join(top_path(getcwd()), CONFIG_NAME)):
-                res.config = join(top_path(getcwd()), CONFIG_NAME)
+                res.config = open(  # pylint:disable=consider-using-with
+                    join(top_path(getcwd()), CONFIG_NAME), encoding="UTF-8"
+                )
 
         if res.config:
             conf = configparser.ConfigParser()

--- a/src/oca_pre_commit_hooks/global_parser.py
+++ b/src/oca_pre_commit_hooks/global_parser.py
@@ -1,0 +1,77 @@
+import argparse
+import configparser
+from os import getcwd
+from os.path import exists, join
+
+from oca_pre_commit_hooks.utils import top_path
+
+CONFIG_NAME = ".oca_hooks.cfg"
+MSG_CTRL = "MESSAGES_CONTROL"
+
+
+def parse_disable(value):
+    return set(value.split(","))
+
+
+class GlobalParser(argparse.ArgumentParser):
+    def __init__(self):
+        super().__init__()
+        self.add_argument(
+            "--no-verbose",
+            action="store_true",
+            default=False,
+            help="If enabled so disable verbose mode.",
+        )
+        self.add_argument(
+            "--no-exit",
+            action="store_true",
+            default=False,
+            help="If enabled so it will not call exit.",
+        )
+        self.add_argument(
+            "--disable",
+            "-d",
+            type=parse_disable,
+            default=set(),
+            help="Disable the checker with the given 'check-name', separated by commas.",
+        )
+        self.add_argument(
+            "--enable",
+            "-e",
+            type=parse_disable,
+            default=set(),
+            help=(
+                "Enable the checker with the given 'check-name', separated by commas. "
+                "Default: All checks are enabled by default"
+            ),
+        )
+        self.add_argument("--config", "-c", type=argparse.FileType("r"), help="Path to a configuration file")
+
+    def parse_args(self, args=None, namespace=None):
+        res = super().parse_args(args)
+
+        # --enable, --disable takes precedence over config file so no point parsing it.
+        if res.enable and res.disable:
+            return res
+
+        if not res.config and exists(join(getcwd(), CONFIG_NAME)):
+            res.config = join(getcwd(), CONFIG_NAME)
+        elif exists(join(top_path(getcwd()), CONFIG_NAME)):
+            res.config = join(top_path(getcwd()), CONFIG_NAME)
+
+        if res.config:
+            conf = configparser.ConfigParser()
+            conf.read_file(res.config)
+
+            if conf.has_section(MSG_CTRL):
+                message_conf = conf[MSG_CTRL]
+                if not res.enable and message_conf.get("enable", None):
+                    res.enable = parse_disable(message_conf.get("enable"))
+                if not res.disable and message_conf.get("disable", None):
+                    res.disable = parse_disable(message_conf.get("disable"))
+
+            res.config.close()
+
+        # Not expected/used by any other program component as of now.
+        delattr(res, "config")
+        return res

--- a/src/oca_pre_commit_hooks/global_parser.py
+++ b/src/oca_pre_commit_hooks/global_parser.py
@@ -54,7 +54,8 @@ class GlobalParser(argparse.ArgumentParser):
             if isfile(join(getcwd(), CONFIG_NAME)):
                 res.config = open(join(getcwd(), CONFIG_NAME), encoding="UTF-8")  # pylint:disable=consider-using-with
             elif isfile(join(top_path(getcwd()), CONFIG_NAME)):
-                res.config = open(  # pylint:disable=consider-using-with
+                # TODO: Add unittest creating a new git repo
+                res.config = open(  # pragma: no cover # pylint:disable=consider-using-with
                     join(top_path(getcwd()), CONFIG_NAME), encoding="UTF-8"
                 )
 

--- a/src/oca_pre_commit_hooks/global_parser.py
+++ b/src/oca_pre_commit_hooks/global_parser.py
@@ -1,7 +1,7 @@
 import argparse
 import configparser
 from os import getcwd
-from os.path import exists, join
+from os.path import isfile, join
 
 from oca_pre_commit_hooks.utils import top_path
 
@@ -54,10 +54,11 @@ class GlobalParser(argparse.ArgumentParser):
         if res.enable and res.disable:
             return res
 
-        if not res.config and exists(join(getcwd(), CONFIG_NAME)):
-            res.config = join(getcwd(), CONFIG_NAME)
-        elif exists(join(top_path(getcwd()), CONFIG_NAME)):
-            res.config = join(top_path(getcwd()), CONFIG_NAME)
+        if not res.config:
+            if isfile(join(getcwd(), CONFIG_NAME)):
+                res.config = join(getcwd(), CONFIG_NAME)
+            elif isfile(join(top_path(getcwd()), CONFIG_NAME)):
+                res.config = join(top_path(getcwd()), CONFIG_NAME)
 
         if res.config:
             conf = configparser.ConfigParser()

--- a/src/oca_pre_commit_hooks/utils.py
+++ b/src/oca_pre_commit_hooks/utils.py
@@ -108,8 +108,7 @@ def chdir(directory):
 @lru_cache(maxsize=256)
 def top_path(path):
     """Get the top level path based on git
-    But if it is not a git repository so the top is the drive name
-    e.g. / or C:\\
+    If no git repository is found (and therefore no top level path), the user's HOME is returned.
 
     It is using lru_cache in order to re-use top level path values
     if multiple files are sharing the same path
@@ -119,7 +118,7 @@ def top_path(path):
             return subprocess.check_output(["git", "rev-parse", "--show-toplevel"]).decode(sys.stdout.encoding).strip()
     except (FileNotFoundError, subprocess.CalledProcessError):
         path = Path(path)
-        return path.root or path.drive
+        return path.root or Path.home()
 
 
 def full_norm_path(path):

--- a/tests/common.py
+++ b/tests/common.py
@@ -95,7 +95,7 @@ class ChecksCommon(unittest.TestCase):
 
     def test_checks_disable_one_by_one_with_cli_conf_file(self):
         file_tmpl = "[MESSAGES_CONTROL]\ndisable=%s"
-        with NamedTemporaryFile(mode="w") as temp_fl:
+        with NamedTemporaryFile(mode="rw") as temp_fl:
             for check2disable in self.expected_errors:
                 content = file_tmpl % check2disable
 
@@ -127,7 +127,7 @@ class ChecksCommon(unittest.TestCase):
 
     def test_checks_enable_one_by_one_with_cli_conf_file(self):
         file_tmpl = "[MESSAGES_CONTROL]\nenable=%s"
-        with NamedTemporaryFile(mode="w") as temp_fl:
+        with NamedTemporaryFile(mode="rw") as temp_fl:
             for check2enable in self.expected_errors:
                 content = file_tmpl % check2enable
 

--- a/tests/common.py
+++ b/tests/common.py
@@ -1,10 +1,10 @@
 import os
 import re
 import sys
+import tempfile
 import unittest
 from collections import defaultdict
 from itertools import chain
-import tempfile
 
 import oca_pre_commit_hooks
 
@@ -98,7 +98,7 @@ class ChecksCommon(unittest.TestCase):
         with tempfile.TemporaryDirectory() as tmp_dir:
             tmp_fname = os.path.join(tmp_dir, "oca.cfg")
             for check2disable in self.expected_errors:
-                with open(tmp_fname, "w") as temp_fl:
+                with open(tmp_fname, "w", encoding="UTF-8") as temp_fl:
                     content = file_tmpl % check2disable
                     temp_fl.write(content)
 
@@ -127,7 +127,7 @@ class ChecksCommon(unittest.TestCase):
         with tempfile.TemporaryDirectory() as tmp_dir:
             tmp_fname = os.path.join(tmp_dir, "oca.cfg")
             for check2enable in self.expected_errors:
-                with open(tmp_fname, "w") as temp_fl:
+                with open(tmp_fname, "w", encoding="UTF-8") as temp_fl:
                     content = file_tmpl % check2enable
                     temp_fl.write(content)
 

--- a/tests/common.py
+++ b/tests/common.py
@@ -4,10 +4,12 @@ import sys
 import tempfile
 import unittest
 from collections import defaultdict
+from contextlib import contextmanager
 from itertools import chain
 
 import oca_pre_commit_hooks
 
+CONFIG_NAME = oca_pre_commit_hooks.global_parser.CONFIG_NAME
 RE_CHECK_DOCSTRING = r"\* Check (?P<check>[\w|\-]+)"
 
 
@@ -39,6 +41,16 @@ def get_checks_docstring(check_classes):
             checks_found |= set(re.findall(RE_CHECK_DOCSTRING, checks_docstring))
             checks_docstring = re.sub(r"( )+\*", "*", checks_docstring)
     return checks_found, checks_docstring
+
+
+@contextmanager
+def chdir(directory):
+    original_dir = os.getcwd()
+    try:
+        os.chdir(directory)
+        yield
+    finally:
+        os.chdir(original_dir)
 
 
 class ChecksCommon(unittest.TestCase):
@@ -96,7 +108,7 @@ class ChecksCommon(unittest.TestCase):
     def test_checks_disable_one_by_one_with_cli_conf_file(self):
         file_tmpl = "[MESSAGES_CONTROL]\ndisable=%s"
         with tempfile.TemporaryDirectory() as tmp_dir:
-            tmp_fname = os.path.join(tmp_dir, "oca.cfg")
+            tmp_fname = os.path.join(tmp_dir, CONFIG_NAME)
             for check2disable in self.expected_errors:
                 with open(tmp_fname, "w", encoding="UTF-8") as temp_fl:
                     content = file_tmpl % check2disable
@@ -125,16 +137,17 @@ class ChecksCommon(unittest.TestCase):
     def test_checks_enable_one_by_one_with_cli_conf_file(self):
         file_tmpl = "[MESSAGES_CONTROL]\nenable=%s"
         with tempfile.TemporaryDirectory() as tmp_dir:
-            tmp_fname = os.path.join(tmp_dir, "oca.cfg")
-            for check2enable in self.expected_errors:
-                with open(tmp_fname, "w", encoding="UTF-8") as temp_fl:
-                    content = file_tmpl % check2enable
-                    temp_fl.write(content)
+            with chdir(tmp_dir):  # Should use the configuration file of the current path
+                tmp_fname = os.path.join(tmp_dir, CONFIG_NAME)
+                for check2enable in self.expected_errors:
+                    with open(tmp_fname, "w", encoding="UTF-8") as temp_fl:
+                        content = file_tmpl % check2enable
+                        temp_fl.write(content)
 
-                sys.argv = ["", "--no-exit", "--no-verbose", f"--config={temp_fl.name}"] + self.file_paths
-                all_check_errors = self.checks_cli_main()
-                real_errors = self.get_count_code_errors(all_check_errors)
-                assertDictEqual(self, real_errors, {check2enable: self.expected_errors[check2enable]})
+                    sys.argv = ["", "--no-exit", "--no-verbose"] + self.file_paths
+                    all_check_errors = self.checks_cli_main()
+                    real_errors = self.get_count_code_errors(all_check_errors)
+                    assertDictEqual(self, real_errors, {check2enable: self.expected_errors[check2enable]})
 
     def test_checks_disable_one_by_one(self):
         for check2disable in self.expected_errors:

--- a/tests/common.py
+++ b/tests/common.py
@@ -4,7 +4,7 @@ import sys
 import unittest
 from collections import defaultdict
 from itertools import chain
-from tempfile import NamedTemporaryFile
+import tempfile
 
 import oca_pre_commit_hooks
 
@@ -95,15 +95,12 @@ class ChecksCommon(unittest.TestCase):
 
     def test_checks_disable_one_by_one_with_cli_conf_file(self):
         file_tmpl = "[MESSAGES_CONTROL]\ndisable=%s"
-        with NamedTemporaryFile(mode="rw") as temp_fl:
+        with tempfile.TemporaryDirectory() as tmp_dir:
+            tmp_fname = os.path.join(tmp_dir, "oca.cfg")
             for check2disable in self.expected_errors:
-                content = file_tmpl % check2disable
-
-                temp_fl.seek(0)
-                temp_fl.write(content)
-                temp_fl.truncate(len(content))
-                temp_fl.flush()
-                os.fsync(temp_fl.fileno())
+                with open(tmp_fname, "w") as temp_fl:
+                    content = file_tmpl % check2disable
+                    temp_fl.write(content)
 
                 expected_errors = self.expected_errors.copy()
                 sys.argv = ["", "--no-exit", "--no-verbose", f"--config={temp_fl.name}"] + self.file_paths
@@ -127,15 +124,12 @@ class ChecksCommon(unittest.TestCase):
 
     def test_checks_enable_one_by_one_with_cli_conf_file(self):
         file_tmpl = "[MESSAGES_CONTROL]\nenable=%s"
-        with NamedTemporaryFile(mode="rw") as temp_fl:
+        with tempfile.TemporaryDirectory() as tmp_dir:
+            tmp_fname = os.path.join(tmp_dir, "oca.cfg")
             for check2enable in self.expected_errors:
-                content = file_tmpl % check2enable
-
-                temp_fl.seek(0)
-                temp_fl.write(content)
-                temp_fl.truncate(len(content))
-                temp_fl.flush()
-                os.fsync(temp_fl.fileno())
+                with open(tmp_fname, "w") as temp_fl:
+                    content = file_tmpl % check2enable
+                    temp_fl.write(content)
 
                 sys.argv = ["", "--no-exit", "--no-verbose", f"--config={temp_fl.name}"] + self.file_paths
                 all_check_errors = self.checks_cli_main()


### PR DESCRIPTION
Fixes #37 

Argument parser was subclassed in order to hook into the `parse_args` method without disrupting the existing code flow. All code downstream does not even know of the existence of a config file and just gets the `enable`, `disable` options as they did before.