### PR TITLE
[IMP] oca_pre_commit_hooks: Support disable XML checks from disable comments

### DIFF
--- a/README.md
+++ b/README.md
@@ -48,6 +48,33 @@ If you install directly the package use the entry point:
     oca-checks-po --help
 
 
+# Skip one xml-check for only one file
+
+If you need to skip one check in one particular XML file you can use the follow comment
+
+```xml
+<?xml version="1.0" encoding="utf-8"?>
+<!-- oca-hooks:disable=xml-check-to-skip -->
+<odoo>
+...
+</odoo>
+```
+
+```xml
+<?xml version="1.0" encoding="utf-8"?>
+<!-- oca-hooks:disable=xml-check-to-skip,
+                       xml-check-to-skip2 -->
+<odoo>
+...
+</odoo>
+```
+
+The position of the comment it is not relative to the line that throw the check
+
+It disable the entire file
+
+
+
 [//]: # (start-checks)
 
 # Checks
@@ -67,7 +94,7 @@ If you install directly the package use the entry point:
 * Check xml-deprecated-data-node
         Deprecated <data> node inside <odoo> xml node
 
-* Check xml-deprecated-openerp-xml-node
+* Check xml-deprecated-openerp-node
         deprecated <openerp> xml node
 
 * Check xml-deprecated-qweb-directive
@@ -248,15 +275,13 @@ options:
     - https://github.com/OCA/odoo-pre-commit-hooks/blob/v0.0.12/test_repo/broken_module/model_view2.xml#L2 Use `<odoo>` instead of `<odoo><data>` or use `<odoo noupdate="1">` instead of `<odoo><data noupdate="1">`
     - https://github.com/OCA/odoo-pre-commit-hooks/blob/v0.0.12/test_repo/broken_module/model_view_odoo.xml#L2 Use `<odoo>` instead of `<odoo><data>` or use `<odoo noupdate="1">` instead of `<odoo><data noupdate="1">`
     - https://github.com/OCA/odoo-pre-commit-hooks/blob/v0.0.12/test_repo/broken_module/model_view_odoo2.xml#L2 Use `<odoo>` instead of `<odoo><data>` or use `<odoo noupdate="1">` instead of `<odoo><data noupdate="1">`
-    - https://github.com/OCA/odoo-pre-commit-hooks/blob/v0.0.12/test_repo/broken_module/skip_xml_check.xml#L3 Use `<odoo>` instead of `<odoo><data>` or use `<odoo noupdate="1">` instead of `<odoo><data noupdate="1">`
-    - https://github.com/OCA/odoo-pre-commit-hooks/blob/v0.0.12/test_repo/broken_module/skip_xml_check_3.xml#L4 Use `<odoo>` instead of `<odoo><data>` or use `<odoo noupdate="1">` instead of `<odoo><data noupdate="1">`
+    - https://github.com/OCA/odoo-pre-commit-hooks/blob/v0.0.12/test_repo/broken_module/skip_xml_check.xml#L4 Use `<odoo>` instead of `<odoo><data>` or use `<odoo noupdate="1">` instead of `<odoo><data noupdate="1">`
     - https://github.com/OCA/odoo-pre-commit-hooks/blob/v0.0.12/test_repo/test_module/model_view.xml#L2 Use `<odoo>` instead of `<odoo><data>` or use `<odoo noupdate="1">` instead of `<odoo><data noupdate="1">`
 
- * xml-deprecated-openerp-xml-node
+ * xml-deprecated-openerp-node
 
     - https://github.com/OCA/odoo-pre-commit-hooks/blob/v0.0.12/test_repo/broken_module/model_view.xml#L2 Deprecated <openerp> xml node
     - https://github.com/OCA/odoo-pre-commit-hooks/blob/v0.0.12/test_repo/broken_module/model_view2.xml#L2 Deprecated <openerp> xml node
-    - https://github.com/OCA/odoo-pre-commit-hooks/blob/v0.0.12/test_repo/broken_module/skip_xml_check_2.xml#L2 Deprecated <openerp> xml node
     - https://github.com/OCA/odoo-pre-commit-hooks/blob/v0.0.12/test_repo/test_module/model_view.xml#L2 Deprecated <openerp> xml node
     - https://github.com/OCA/odoo-pre-commit-hooks/blob/v0.0.12/test_repo/test_module/res_users.xml#L2 Deprecated <openerp> xml node
 
@@ -286,7 +311,6 @@ options:
  * xml-duplicate-record-id
 
     - https://github.com/OCA/odoo-pre-commit-hooks/blob/v0.0.12/test_repo/broken_module/model_view.xml#L5 Duplicate xml record id "data/view_model_form_noupdate_0" in test_repo/broken_module/model_view_odoo.xml:5, test_repo/broken_module/model_view_odoo2.xml:5
-    - https://github.com/OCA/odoo-pre-commit-hooks/blob/v0.0.12/test_repo/broken_module/model_view2.xml#L103 Duplicate xml record id "data/view_model_form80_noupdate_0" in test_repo/broken_module/skip_xml_check.xml:5, test_repo/broken_module/skip_xml_check.xml:9, test_repo/broken_module/skip_xml_check_3.xml:6, test_repo/broken_module/skip_xml_check_3.xml:10
     - https://github.com/OCA/odoo-pre-commit-hooks/blob/v0.0.12/test_repo/broken_module/model_view2.xml#L5 Duplicate xml record id "data/view_model_form2_noupdate_0" in test_repo/broken_module/model_view_odoo2.xml:17
 
  * xml-not-valid-char-link

--- a/src/oca_pre_commit_hooks/checks_odoo_module.py
+++ b/src/oca_pre_commit_hooks/checks_odoo_module.py
@@ -151,6 +151,10 @@ def run(files_or_modules, enable=None, disable=None, no_verbose=False, no_exit=F
     # TODO: Add unnitest to check files filtered from pre-commit by hook
     # Uncommet to check what files sent pre-commit
     # open("/tmp/borrar.txt", "w").write(f"{len(files_or_modules)}\n{files_or_modules}")
+    if enable is None:
+        enable = set()
+    if disable is None:
+        disable = set()
     for manifest_path, changed in lookup_manifest_paths(files_or_modules).items():
         if not manifest_path:
             continue

--- a/src/oca_pre_commit_hooks/checks_odoo_module_csv.py
+++ b/src/oca_pre_commit_hooks/checks_odoo_module_csv.py
@@ -10,7 +10,6 @@ class ChecksOdooModuleCSV:
         self.manifest_datas = manifest_datas
         self.module_name = module_name
         self.enable = enable
-        self.enable = disable
         self.disable = disable
         for manifest_data in manifest_datas:
             manifest_data.update(

--- a/test_repo/broken_module/__openerp__.py
+++ b/test_repo/broken_module/__openerp__.py
@@ -17,6 +17,7 @@
         'skip_xml_check_3.xml',
         'report.xml',
         'template1.xml',
+        'template1_disable.xml',
         'ir.model.access.csv',
     ],
     'demo': ['demo/duplicated_id_demo.xml', 'file_no_exist.xml'],

--- a/test_repo/broken_module/skip_file_no_used.xml
+++ b/test_repo/broken_module/skip_file_no_used.xml
@@ -1,4 +1,4 @@
 <?xml version="1.0" encoding="utf-8"?>
-<!-- pylint:disable=file-not-used -->
+<!-- oca-hooks:disable=file-not-used -->
 <odoo>
 </odoo>

--- a/test_repo/broken_module/skip_file_not_used.xml
+++ b/test_repo/broken_module/skip_file_not_used.xml
@@ -1,4 +1,4 @@
 <?xml version="1.0" encoding="utf-8"?>
-<!-- pylint:disable=file-not-used -->
+<!-- oca-hooks:disable=file-not-used -->
 <odoo>
 </odoo>

--- a/test_repo/broken_module/skip_xml_check.xml
+++ b/test_repo/broken_module/skip_xml_check.xml
@@ -1,5 +1,6 @@
 <?xml version="1.0" encoding="utf-8"?>
-<!-- pylint:disable=deprecated-data-xml-node, duplicate-xml-record-id -->
+<!-- oca-hooks:disable=xml-deprecated-openerp-node, 
+               xml-duplicate-record-id -->
 <odoo>
     <data>
         <record id="view_model_form80" model="ir.ui.view">

--- a/test_repo/broken_module/skip_xml_check_2.xml
+++ b/test_repo/broken_module/skip_xml_check_2.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="utf-8"?>
-<openerp> <!-- pylint: disable=deprecated-openerp-xml-node -->
+<openerp> <!-- oca-hooks: disable=xml-deprecated-openerp-node -->
     <data>
     </data>
 </openerp>

--- a/test_repo/broken_module/skip_xml_check_3.xml
+++ b/test_repo/broken_module/skip_xml_check_3.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="utf-8"?>
-<!-- pylint : disable=deprecated-data-xml-node,
-                    duplicate-xml-record-id -->
+<!-- oca-hooks : disable=xml-deprecated-data-node,
+                    xml-duplicate-record-id -->
 <odoo>
     <data>
         <record id="view_model_form80" model="ir.ui.view">

--- a/test_repo/broken_module/template1_disable.xml
+++ b/test_repo/broken_module/template1_disable.xml
@@ -1,0 +1,29 @@
+<?xml version="1.0" encoding="utf-8"?>
+<odoo>
+    <!-- oca-hooks:disable=xml-dangerous-qweb-replace-low-priority -->
+    <template id="my_template1" inherit_id="module.template">
+        <xpath expr="//div[@role='search']" position="replace">
+            <form/>
+        </xpath>
+        <xpath expr="//div[@role='search']" position="replace"/>
+    </template>
+
+    <template id="my_template2" inherit_id="module.template" priority="110">
+        <xpath expr="//div[@role='search']" position="replace">
+            <form/>
+        </xpath>
+        <xpath expr="//div[@role='search']" position="replace"/>
+    </template>
+
+    <template id="my_template3" inherit_id="module.template">
+        <t t-set="address" position="replace"/>
+    </template>
+
+    <template id="my_template4" inherit_id="module.template" priority="110">
+        <t t-set="address" position="replace"/>
+    </template>
+
+    <template id="my_template5" inherit_id="module.template">
+        <t t-set="address"/>
+    </template>
+</odoo>

--- a/test_repo/test_module/__openerp__.py
+++ b/test_repo/test_module/__openerp__.py
@@ -13,6 +13,7 @@
         'model_view.xml',
         'model_view.xml',
         'website_templates.xml',
+        'website_templates_disable.xml',
     ],
     'external_dependencies': {
         'bin': [

--- a/test_repo/test_module/website_templates_disable.xml
+++ b/test_repo/test_module/website_templates_disable.xml
@@ -1,0 +1,37 @@
+<?xml version="1.0" encoding="utf-8"?>
+<odoo>
+
+    <!-- oca-hooks:disable=xml-deprecated-qweb-directive,
+                   xml-not-valid-char-link -->
+    <!-- Deprecated QWeb directive "t-esc-options". -->
+    <template id="test_template_1" name="Test Template 1">
+        <div>
+            <span t-esc="price" t-esc-options='{"widget": "monetary"}'/>
+        </div>
+    </template>
+
+    <!-- Deprecated QWeb directive "t-field-options". -->
+    <template id="test_template_2" name="Test Template 2">
+        <div>
+            <span t-field="line.image" t-field-options='{"widget": "image"}'/>
+        </div>
+    </template>
+
+    <template id="assets_backend" name="test_module_widget" inherit_id="web.assets_backend">
+        <xpath expr="." position="inside">
+            <!-- Wrong but is working in odoo web debug mode -->
+            <link rel="stylesheet" href="/test_module_widget/static/widget.css?v=1"/>
+
+            <script type="text/javascript" src="/test_module_affiliation_widget/static/widget.js?v=1"/>
+
+            <!-- Correct but is working working odoo web debug mode also -->
+            <link rel="stylesheet" href="/test_module_widget/static/widget.css"/>
+
+            <script type="text/javascript" src="/test_module_affiliation_widget/static/widget.js"/>
+
+            <script type="text/javascript" src="https://code.jquery.com/jquery-3.2.1.min.js"/>
+            <script type="text/javascript" src="https://code.jquery.com/jquery-3.2.1.min.js?_ca=235"/>
+        </xpath>
+    </template>
+
+</odoo>

--- a/tests/common.py
+++ b/tests/common.py
@@ -73,7 +73,7 @@ class ChecksCommon(unittest.TestCase):
         all_check_errors = self.checks_run(self.file_paths, no_exit=True, no_verbose=False)
         real_errors = self.get_count_code_errors(all_check_errors)
         # Uncommet to get sorted values to update EXPECTED_ERRORS dict
-        # print('\n'.join(f"'{key}':{count_code_errors[key]}," for key in sorted(count_code_errors)))
+        # print("\n".join(f"'{key}':{real_errors[key]}," for key in sorted(real_errors)))
         assertDictEqual(self, real_errors, self.expected_errors)
 
     def test_checks_with_cli(self):

--- a/tests/test_checks.py
+++ b/tests/test_checks.py
@@ -15,6 +15,7 @@ ALL_CHECK_CLASS = [
     oca_pre_commit_hooks.checks_odoo_module_xml.ChecksOdooModuleXML,
 ]
 
+
 EXPECTED_ERRORS = {
     "csv-duplicate-record-id": 1,
     "csv-syntax-error": 1,
@@ -22,12 +23,12 @@ EXPECTED_ERRORS = {
     "xml-create-user-wo-reset-password": 1,
     "xml-dangerous-filter-wo-user": 1,
     "xml-dangerous-qweb-replace-low-priority": 3,
-    "xml-deprecated-data-node": 8,
-    "xml-deprecated-openerp-xml-node": 5,
+    "xml-deprecated-data-node": 7,
+    "xml-deprecated-openerp-node": 4,
     "xml-deprecated-qweb-directive": 2,
     "xml-deprecated-tree-attribute": 3,
     "xml-duplicate-fields": 9,
-    "xml-duplicate-record-id": 3,
+    "xml-duplicate-record-id": 2,
     "xml-not-valid-char-link": 2,
     "xml-redundant-module-name": 1,
     "xml-syntax-error": 2,

--- a/tox.ini
+++ b/tox.ini
@@ -67,7 +67,7 @@ setenv =
 commands =
     # Workaround https://github.com/tox-dev/tox/issues/1571
     python -c 'from glob import glob; import subprocess; [subprocess.check_call(["coverage", "combine", "--keep", i]) for i in glob(".coverage.*")]'
-    coverage report
+    coverage report --fail-under=0  # The next command will fail instead but will allow to see the html report
     coverage html
 
 [testenv:clean]


### PR DESCRIPTION
Add support to disable checks for XML files based on comments

e.g.

```xml
    <?xml version="1.0" encoding="utf-8"?>
    <!-- oca-hooks:disable=xml-deprecated-openerp-node -->
    <odoo>
    ...
    </odoo>
```

In this case the check `xml-deprecated-openerp-node` will be disabled only for this file

Fix https://github.com/OCA/odoo-pre-commit-hooks/issues/40