### PR TITLE
[IMP] oca_pre_commit_hooks: Add --list-msgs option (#44)

### DIFF
--- a/README.md
+++ b/README.md
@@ -190,7 +190,7 @@ It disable the entire file
 ```bash
 usage: oca-checks-odoo-module [-h] [--no-verbose] [--no-exit]
                               [--disable DISABLE] [--enable ENABLE]
-                              [--config CONFIG]
+                              [--config CONFIG] [--list-msgs]
                               [files_or_modules ...]
 
 positional arguments:
@@ -209,6 +209,7 @@ options:
                         by default
   --config CONFIG, -c CONFIG
                         Path to a configuration file
+  --list-msgs           List all currently enabled messages.
 
 ```
 
@@ -220,7 +221,7 @@ options:
 # Help PO
 ```bash
 usage: oca-checks-po [-h] [--no-verbose] [--no-exit] [--disable DISABLE]
-                     [--enable ENABLE] [--config CONFIG]
+                     [--enable ENABLE] [--config CONFIG] [--list-msgs]
                      [po_files ...]
 
 positional arguments:
@@ -239,6 +240,7 @@ options:
                         by default
   --config CONFIG, -c CONFIG
                         Path to a configuration file
+  --list-msgs           List all currently enabled messages.
 
 ```
 

--- a/src/oca_pre_commit_hooks/checks_odoo_module.py
+++ b/src/oca_pre_commit_hooks/checks_odoo_module.py
@@ -5,6 +5,8 @@ import os
 import sys
 from collections import defaultdict
 
+from common import get_checks_docstring
+
 from oca_pre_commit_hooks import checks_odoo_module_csv, checks_odoo_module_xml, utils
 
 DFTL_README_TMPL_URL = "https://github.com/OCA/maintainer-tools/blob/master/template/module/README.rst"  # noqa: B950
@@ -159,7 +161,16 @@ def lookup_manifest_paths(filenames_or_modules):
     return odoo_module_files_changed
 
 
-def run(files_or_modules, enable=None, disable=None, no_verbose=False, no_exit=False):
+def run(files_or_modules, enable=None, disable=None, no_verbose=False, no_exit=False, list_msgs=False):
+    if list_msgs:
+        _, checks_docstring = get_checks_docstring(
+            [ChecksOdooModule, checks_odoo_module_csv.ChecksOdooModuleCSV, checks_odoo_module_xml.ChecksOdooModuleXML]
+        )
+        print("Emittable messages with the current interpreter:", end="")
+        print(checks_docstring)
+
+        sys.exit(0)
+
     all_check_errors = []
     # TODO: Add unnitest to check files filtered from pre-commit by hook
     # Uncommet to check what files sent pre-commit

--- a/src/oca_pre_commit_hooks/checks_odoo_module.py
+++ b/src/oca_pre_commit_hooks/checks_odoo_module.py
@@ -5,8 +5,6 @@ import os
 import sys
 from collections import defaultdict
 
-from common import get_checks_docstring
-
 from oca_pre_commit_hooks import checks_odoo_module_csv, checks_odoo_module_xml, utils
 
 DFTL_README_TMPL_URL = "https://github.com/OCA/maintainer-tools/blob/master/template/module/README.rst"  # noqa: B950
@@ -163,7 +161,7 @@ def lookup_manifest_paths(filenames_or_modules):
 
 def run(files_or_modules, enable=None, disable=None, no_verbose=False, no_exit=False, list_msgs=False):
     if list_msgs:
-        _, checks_docstring = get_checks_docstring(
+        _, checks_docstring = utils.get_checks_docstring(
             [ChecksOdooModule, checks_odoo_module_csv.ChecksOdooModuleCSV, checks_odoo_module_xml.ChecksOdooModuleXML]
         )
         print("Emittable messages with the current interpreter:", end="")

--- a/src/oca_pre_commit_hooks/checks_odoo_module.py
+++ b/src/oca_pre_commit_hooks/checks_odoo_module.py
@@ -164,9 +164,11 @@ def run(files_or_modules, enable=None, disable=None, no_verbose=False, no_exit=F
         _, checks_docstring = utils.get_checks_docstring(
             [ChecksOdooModule, checks_odoo_module_csv.ChecksOdooModuleCSV, checks_odoo_module_xml.ChecksOdooModuleXML]
         )
-        print("Emittable messages with the current interpreter:", end="")
-        print(checks_docstring)
-
+        if not no_verbose:
+            print("Emittable messages with the current interpreter:", end="")
+            print(checks_docstring)
+        if no_exit:
+            return checks_docstring
         sys.exit(0)
 
     all_check_errors = []

--- a/src/oca_pre_commit_hooks/checks_odoo_module_po.py
+++ b/src/oca_pre_commit_hooks/checks_odoo_module_po.py
@@ -303,10 +303,11 @@ class ChecksOdooModulePO:
 def run(po_files, enable=None, disable=None, no_verbose=False, no_exit=False, list_msgs=False):
     if list_msgs:
         _, checks_docstring = utils.get_checks_docstring([ChecksOdooModulePO])
-        print("Emittable messages with the current interpreter:", end="")
-        print(checks_docstring)
+        if not no_verbose:
+            print("Emittable messages with the current interpreter:", end="")
+            print(checks_docstring)
         if no_exit:
-            return True
+            return checks_docstring
         sys.exit(0)
 
     all_check_errors = []

--- a/src/oca_pre_commit_hooks/checks_odoo_module_po.py
+++ b/src/oca_pre_commit_hooks/checks_odoo_module_po.py
@@ -5,7 +5,6 @@ import sys
 from collections import defaultdict
 
 import polib
-from common import get_checks_docstring
 
 from oca_pre_commit_hooks import utils
 
@@ -303,10 +302,11 @@ class ChecksOdooModulePO:
 
 def run(po_files, enable=None, disable=None, no_verbose=False, no_exit=False, list_msgs=False):
     if list_msgs:
-        _, checks_docstring = get_checks_docstring([ChecksOdooModulePO])
+        _, checks_docstring = utils.get_checks_docstring([ChecksOdooModulePO])
         print("Emittable messages with the current interpreter:", end="")
         print(checks_docstring)
-
+        if no_exit:
+            return True
         sys.exit(0)
 
     all_check_errors = []

--- a/src/oca_pre_commit_hooks/checks_odoo_module_po.py
+++ b/src/oca_pre_commit_hooks/checks_odoo_module_po.py
@@ -5,6 +5,7 @@ import sys
 from collections import defaultdict
 
 import polib
+from common import get_checks_docstring
 
 from oca_pre_commit_hooks import utils
 
@@ -300,7 +301,14 @@ class ChecksOdooModulePO:
                 print(f"{msg} - [{check_error}]")
 
 
-def run(po_files, enable=None, disable=None, no_verbose=False, no_exit=False):
+def run(po_files, enable=None, disable=None, no_verbose=False, no_exit=False, list_msgs=False):
+    if list_msgs:
+        _, checks_docstring = get_checks_docstring([ChecksOdooModulePO])
+        print("Emittable messages with the current interpreter:", end="")
+        print(checks_docstring)
+
+        sys.exit(0)
+
     all_check_errors = []
     exit_status = 0
     for po_file in po_files:

--- a/src/oca_pre_commit_hooks/global_parser.py
+++ b/src/oca_pre_commit_hooks/global_parser.py
@@ -49,6 +49,9 @@ class GlobalParser(argparse.ArgumentParser):
             ),
         )
         self.add_argument("--config", "-c", type=argparse.FileType("r"), help="Path to a configuration file")
+        self.add_argument(
+            "--list-msgs", default=False, action="store_true", help="List all currently enabled messages."
+        )
 
     @staticmethod
     def _default_env_csv(env_var):

--- a/src/oca_pre_commit_hooks/utils.py
+++ b/src/oca_pre_commit_hooks/utils.py
@@ -4,9 +4,11 @@ import subprocess
 import sys
 from contextlib import contextmanager
 from functools import lru_cache
+from itertools import chain
 from pathlib import Path
 
 CHECKS_DISABLED_REGEX = re.compile(re.escape("oca-hooks:disable=") + r"([a-z\-,]+)")
+RE_CHECK_DOCSTRING = r"\* Check (?P<check>[\w|\-]+)"
 
 
 def checks_disabled(comment):
@@ -156,3 +158,24 @@ def filter_checks_enabled_disabled(checks_errors, enables, disables):
     checks_no_enable = set(checks_errors) - enables
     for check_no_enable in checks_no_enable:
         checks_errors.pop(check_no_enable, False)
+
+
+def get_checks_docstring(check_classes):
+    checks_docstring = ""
+    checks_found = set()
+    for check_class in check_classes:
+        check_meths = chain(
+            getattr_checks(check_class, prefix="visit"),
+            getattr_checks(check_class, prefix="check"),
+        )
+        # Sorted to avoid mutable checks order readme
+        check_meths = sorted(
+            list(check_meths), key=lambda m: m.__name__.replace("visit", "", 1).replace("check", "", 1).strip("_")
+        )
+        for check_meth in check_meths:
+            if not check_meth or not check_meth.__doc__ or "* Check" not in check_meth.__doc__:
+                continue
+            checks_docstring += "\n" + check_meth.__doc__.strip(" \n") + "\n"
+            checks_found |= set(re.findall(RE_CHECK_DOCSTRING, checks_docstring))
+            checks_docstring = re.sub(r"( )+\*", "*", checks_docstring)
+    return checks_found, checks_docstring

--- a/tests/common.py
+++ b/tests/common.py
@@ -5,12 +5,8 @@ import tempfile
 import unittest
 from collections import defaultdict
 from contextlib import contextmanager
-from itertools import chain
 
-import oca_pre_commit_hooks
 from oca_pre_commit_hooks.global_parser import CONFIG_NAME, DISABLE_ENV_VAR, ENABLE_ENV_VAR
-
-RE_CHECK_DOCSTRING = r"\* Check (?P<check>[\w|\-]+)"
 
 
 def assertDictEqual(self, d1, d2, msg=None):
@@ -20,27 +16,6 @@ def assertDictEqual(self, d1, d2, msg=None):
     real_dict2list = [(i, d1[i]) for i in sorted(d1)]
     expected_dict2list = [(i, d2[i]) for i in sorted(d2)]
     self.assertEqual(real_dict2list, expected_dict2list, msg)
-
-
-def get_checks_docstring(check_classes):
-    checks_docstring = ""
-    checks_found = set()
-    for check_class in check_classes:
-        check_meths = chain(
-            oca_pre_commit_hooks.utils.getattr_checks(check_class, prefix="visit"),
-            oca_pre_commit_hooks.utils.getattr_checks(check_class, prefix="check"),
-        )
-        # Sorted to avoid mutable checks order readme
-        check_meths = sorted(
-            list(check_meths), key=lambda m: m.__name__.replace("visit", "", 1).replace("check", "", 1).strip("_")
-        )
-        for check_meth in check_meths:
-            if not check_meth or not check_meth.__doc__ or "* Check" not in check_meth.__doc__:
-                continue
-            checks_docstring += "\n" + check_meth.__doc__.strip(" \n") + "\n"
-            checks_found |= set(re.findall(RE_CHECK_DOCSTRING, checks_docstring))
-            checks_docstring = re.sub(r"( )+\*", "*", checks_docstring)
-    return checks_found, checks_docstring
 
 
 @contextmanager

--- a/tests/common.py
+++ b/tests/common.py
@@ -6,6 +6,7 @@ import unittest
 from collections import defaultdict
 from contextlib import contextmanager
 
+from oca_pre_commit_hooks import utils
 from oca_pre_commit_hooks.global_parser import CONFIG_NAME, DISABLE_ENV_VAR, ENABLE_ENV_VAR
 
 
@@ -240,3 +241,8 @@ class ChecksCommon(unittest.TestCase):
                 expected_errors.pop(conf_check)
                 real_errors = self.get_count_code_errors(self.checks_cli_main())
                 assertDictEqual(self, real_errors, expected_errors)
+
+    def test_list_messages(self):
+        all_messages = self.checks_run([], list_msgs=True, no_exit=True, no_verbose=False)
+        checks_found = re.findall(utils.RE_CHECK_DOCSTRING, all_messages)
+        self.assertFalse(set(self.expected_errors) - set(checks_found), "Missing list-message of checks")

--- a/tests/test_checks.py
+++ b/tests/test_checks.py
@@ -80,7 +80,7 @@ class TestChecksWithFiles(common.ChecksCommon):
         # and we do not have way to evaluate all checks are evaluated and documented from another side
         # Feel free to migrate to better place this non-standard section of the code
 
-        checks_found, checks_docstring = common.get_checks_docstring(ALL_CHECK_CLASS)
+        checks_found, checks_docstring = oca_pre_commit_hooks.utils.get_checks_docstring(ALL_CHECK_CLASS)
         readme_path = os.path.join(os.path.dirname(os.path.dirname(os.path.realpath(__file__))), "README.md")
         with open(readme_path, encoding="UTF-8") as f_readme:
             readme_content = f_readme.read()

--- a/tests/test_checks_po.py
+++ b/tests/test_checks_po.py
@@ -47,7 +47,7 @@ class TestChecksPO(common.ChecksCommon):
     @unittest.skipIf(not os.environ.get("BUILD_README"), "BUILD_README environment variable not enabled")
     def test_build_docstring(self):
 
-        checks_found, checks_docstring = common.get_checks_docstring(
+        checks_found, checks_docstring = oca_pre_commit_hooks.utils.get_checks_docstring(
             [oca_pre_commit_hooks.checks_odoo_module_po.ChecksOdooModulePO]
         )
 


### PR DESCRIPTION
Fixes #44 
Calling entry points with the argument `--list-msgs` prints out a list of all enabled messages.