### PR TITLE
[FIX] checks_odoo_module: Support glob expression for "qweb" manifest data section

### DIFF
--- a/README.md
+++ b/README.md
@@ -281,6 +281,9 @@ options:
     - https://github.com/OCA/odoo-pre-commit-hooks/blob/v0.0.17/test_repo/broken_module/template1_copy.xml#L18 Dangerous use of "replace" from view with priority `0 < 99`
     - https://github.com/OCA/odoo-pre-commit-hooks/blob/v0.0.17/test_repo/broken_module/template1_copy.xml#L4 Dangerous use of "replace" from view with priority `0 < 99`
     - https://github.com/OCA/odoo-pre-commit-hooks/blob/v0.0.17/test_repo/broken_module/template1_copy.xml#L7 Dangerous use of "replace" from view with priority `0 < 99`
+    - https://github.com/OCA/odoo-pre-commit-hooks/blob/v0.0.17/test_repo/broken_module/template1_copy2.xml#L18 Dangerous use of "replace" from view with priority `0 < 99`
+    - https://github.com/OCA/odoo-pre-commit-hooks/blob/v0.0.17/test_repo/broken_module/template1_copy2.xml#L4 Dangerous use of "replace" from view with priority `0 < 99`
+    - https://github.com/OCA/odoo-pre-commit-hooks/blob/v0.0.17/test_repo/broken_module/template1_copy2.xml#L7 Dangerous use of "replace" from view with priority `0 < 99`
 
  * xml-deprecated-data-node
 
@@ -355,6 +358,7 @@ options:
     - https://github.com/OCA/odoo-pre-commit-hooks/blob/v0.0.17/test_repo/broken_module/model_view.xml#L11 Use of translatable xpath `text()`
     - https://github.com/OCA/odoo-pre-commit-hooks/blob/v0.0.17/test_repo/broken_module/template1.xml#L31 Use of translatable xpath `text()`
     - https://github.com/OCA/odoo-pre-commit-hooks/blob/v0.0.17/test_repo/broken_module/template1_copy.xml#L31 Use of translatable xpath `text()`
+    - https://github.com/OCA/odoo-pre-commit-hooks/blob/v0.0.17/test_repo/broken_module/template1_copy2.xml#L31 Use of translatable xpath `text()`
 
 [//]: # (end-example)
 

--- a/test_repo/broken_module/__openerp__.py
+++ b/test_repo/broken_module/__openerp__.py
@@ -8,7 +8,7 @@
     'version': '8_0.1.0.0',
     'website': 'https://odoo-community.org',
     'depends': ['base'],
-    'qweb': ['template1.xml',],
+    'qweb': ['template1.xml', '*emplate1_copy2.xml'],
     'assets': {
         'point_of_sale.assets': [
             'broken_module/*emplate1_copy.xml',

--- a/test_repo/broken_module/template1_copy2.xml
+++ b/test_repo/broken_module/template1_copy2.xml
@@ -1,0 +1,39 @@
+<?xml version="1.0" encoding="utf-8"?>
+<odoo>
+    <template id="my_template1" inherit_id="module.template">
+        <xpath expr="//div[@role='search']" position="replace">
+            <form/>
+        </xpath>
+        <xpath expr="//div[@role='search']" position="replace"/>
+    </template>
+
+    <template id="my_template2" inherit_id="module.template" priority="110">
+        <xpath expr="//div[@role='search']" position="replace">
+            <form/>
+        </xpath>
+        <xpath expr="//div[@role='search']" position="replace"/>
+    </template>
+
+    <template id="my_template3" inherit_id="module.template">
+        <t t-set="address" position="replace"/>
+    </template>
+
+    <template id="my_template4" inherit_id="module.template" priority="110">
+        <t t-set="address" position="replace"/>
+    </template>
+
+    <template id="my_template5" inherit_id="module.template">
+        <t t-set="address"/>
+    </template>
+
+    <templates id="my_template_xpath" xml:space="preserve">
+        <t t-name="t-name" t-inherit="module.Inherited" t-inherit-mode="extension" owl="1">
+            <xpath expr="//div[contains(text(), 'Translatable Value')]" position="replace">
+                <div>
+                    <t>New Value</t>
+                </div>
+            </xpath>
+        </t>
+    </templates>
+
+</odoo>

--- a/tests/test_checks.py
+++ b/tests/test_checks.py
@@ -22,7 +22,7 @@ EXPECTED_ERRORS = {
     "manifest-syntax-error": 2,
     "xml-create-user-wo-reset-password": 1,
     "xml-dangerous-filter-wo-user": 1,
-    "xml-dangerous-qweb-replace-low-priority": 6,
+    "xml-dangerous-qweb-replace-low-priority": 9,
     "xml-deprecated-data-node": 7,
     "xml-deprecated-openerp-node": 4,
     "xml-deprecated-qweb-directive": 2,
@@ -33,7 +33,7 @@ EXPECTED_ERRORS = {
     "xml-redundant-module-name": 1,
     "xml-syntax-error": 2,
     "xml-view-dangerous-replace-low-priority": 6,
-    "xml-xpath-translatable-item": 3,
+    "xml-xpath-translatable-item": 4,
 }
 
 


### PR DESCRIPTION
"qweb" is compatible using glob expressions from the manifest data file

It was raising xml-syntax-error because the file was not found

Something like:

    module/static/src/xml/*.xml:1 [Errno 2] No such file or directory: '' - []

It was fixed using processing the glob expression but qweb is not using the module name as prefix