### PR TITLE
[FIX] xml-xpath-translatable-item: Fix false negative calling a method `o.amount_to_text()`

### DIFF
--- a/src/oca_pre_commit_hooks/checks_odoo_module_xml.py
+++ b/src/oca_pre_commit_hooks/checks_odoo_module_xml.py
@@ -348,7 +348,8 @@ class ChecksOdooModuleXML:
         """
         for manifest_data in self.manifest_datas:
             for xpath_node in manifest_data["node"].xpath("//xpath"):
-                if "text()" in (xpath_node.get("expr") or ""):
+                node_expr = (xpath_node.get("expr") or "").replace(" ", "")
+                if "[contains(text()" in node_expr or "[text()=" in node_expr:
                     self.checks_errors["xml-xpath-translatable-item"].append(
                         f'{manifest_data["filename_short"]}:{xpath_node.sourceline} '
                         f"Use of translatable xpath `text()`"

--- a/test_repo/broken_module/model_view.xml
+++ b/test_repo/broken_module/model_view.xml
@@ -11,6 +11,9 @@
                     <xpath expr="//div[contains(text(), 'Translatable String')]/more/path" position="attributes">
                         <attribute name="t-if">o.value</attribute>
                     </xpath>
+                    <xpath expr="//span[@t-esc='o.amount_to_text()']/.." position="after">
+                        <attribute name="t-if">o.value</attribute>
+                    </xpath>
                 </form>
             </field>
         </record>


### PR DESCRIPTION
Use of translatable xpath `text()` - [xml-xpath-translatable-item]
