### PR TITLE
[ADD] hooks: New unused python file check

### DIFF
--- a/.pre-commit-hooks.yaml
+++ b/.pre-commit-hooks.yaml
@@ -23,3 +23,9 @@
   types_or: ["text"]
   files: \.(po|pot)$
   require_serial: false
+- id: oca-check-unused-python-file
+  name: Check unused python files
+  entry: oca-check-unused-python-file
+  language: python
+  types: [python]
+  files: (controllers|models|report|wizard)\.py$|tests\/test_.*\.py$

--- a/setup.py
+++ b/setup.py
@@ -93,6 +93,7 @@ setup(
         "console_scripts": [
             "oca-checks-odoo-module = oca_pre_commit_hooks.cli:main",
             "oca-checks-po = oca_pre_commit_hooks.cli_po:main",
+            "oca-check-unused-python-file = oca_pre_commit_hooks.check_unused_python_file:main",
         ]
     },
 )

--- a/src/oca_pre_commit_hooks/check_unused_python_file.py
+++ b/src/oca_pre_commit_hooks/check_unused_python_file.py
@@ -1,0 +1,39 @@
+import argparse
+import ast
+import functools
+import os
+from typing import List, Set, Union
+
+
+@functools.lru_cache()
+def get_imported_files(dirname: str) -> Set[str]:
+    imported_files = set()
+    init_file = os.path.join(dirname, "__init__.py")
+    if os.path.exists(init_file):
+        with open(init_file, encoding="utf-8") as init_fd:
+            init_ast = ast.parse(init_fd.read())
+
+        if isinstance(init_ast.body, list):
+            for module in filter(lambda elem: isinstance(elem, ast.ImportFrom), init_ast.body):
+                for name in module.names:
+                    imported_files.add(name.name)
+
+    return imported_files
+
+
+def check_unused_python_file(filenames: List[str]) -> int:
+    status = 0
+    for filename in filenames:
+        if os.path.basename(filename)[:-3] not in get_imported_files(os.path.dirname(filename)):
+            print(f"{filename}: not imported")
+            status = -1
+
+    return status
+
+
+def main(argv: Union[List[str], None] = None) -> int:
+    parser = argparse.ArgumentParser()
+    parser.add_argument("filenames", nargs="*")
+    args = parser.parse_args(argv)
+
+    return check_unused_python_file(args.filenames)

--- a/tests/test_check_unused_python_file.py
+++ b/tests/test_check_unused_python_file.py
@@ -1,0 +1,60 @@
+import os
+from pathlib import Path
+from typing import List
+
+from oca_pre_commit_hooks.check_unused_python_file import main
+
+FILE_NAMES = ["res_partner", "project_task", "helpdesk_ticket"]
+
+
+def _gen_filepaths(filenames: List[str], basedir) -> List[str]:
+    return [f"{os.path.join(basedir, filename)}.py" for filename in filenames]
+
+
+def test_all_used_files(tmpdir):
+    filepaths = _gen_filepaths(FILE_NAMES, tmpdir)
+    init_file = os.path.join(tmpdir, "__init__.py")
+    with open(init_file, "w", encoding="utf-8") as init_fd:
+        init_fd.writelines([f"from . import {filename}\n" for filename in FILE_NAMES])
+
+    for filepath in filepaths:
+        Path(filepath).touch()
+
+    assert main(filepaths) == 0
+
+    Path(init_file).unlink()
+    with open(init_file, "w", encoding="utf-8") as init_fd:
+        init_fd.write(f"from . import {','.join(FILE_NAMES)}")
+
+    assert main(filepaths) == 0
+
+
+def test_all_unused_files(tmpdir):
+    filepaths = _gen_filepaths(FILE_NAMES, tmpdir)
+    init_file = os.path.join(tmpdir, "__init__.py")
+
+    Path(init_file).touch()
+    for filepath in filepaths:
+        Path(filepath).touch()
+
+    assert main(filepaths) == -1
+
+
+def test_complex_init(tmpdir):
+    filepaths = _gen_filepaths(FILE_NAMES, tmpdir)
+    init_file = os.path.join(tmpdir, "__init__.py")
+    with open(init_file, "w", encoding="utf-8") as init_fd:
+        init_fd.writelines(
+            ["def hello(cr):\n", "\treturn cr.commit()\n"] + [f"from . import {filename}\n" for filename in FILE_NAMES]
+        )
+
+    for filepath in filepaths:
+        Path(filepath).touch()
+
+    assert main(filepaths) == 0
+
+    extra_file = os.path.join(tmpdir, "extrafile.py")
+    Path(extra_file).touch()
+    filepaths.append(extra_file)
+
+    assert main(filepaths) == -1


### PR DESCRIPTION
Unused python files are considered python files not imported in their corresponding __init__.py file. This only applies to actual files that need to be imported, as it only checks python files in standard locations that must be imported by odoo. This includes the following folders:

- controllers
- models
- report
- wizard
- tests (only if it starts with `test_`)

Related to: https://github.com/Vauxoo/pylint-odoo/issues/177

I decided against placing this checker in pylint since the entry point for it would be ugly and probably involve non standard code (aka can't be easily done with `visit_` functions). I also did not introduce this into an existing hook since its correct functioning depends on the right `files` setting on `pre-commit-hooks.yaml`.

The code structure does not fill very well with existing code, but I think it might fit well after a restructuring, and I personally believe this is the most correct way to implement the desired check.

When run against Odoo 16.0 I get the following output:
```
Check unused python files................................................Failed
- hook id: oca-check-unused-python-file
- exit code: 255

addons/microsoft_calendar/tests/test_sync_odoo2microsoft.py: not imported
addons/microsoft_calendar/tests/test_sync_microsoft2odoo.py: not imported
odoo/addons/base/tests/test_uninstall.py: not imported
addons/lunch/tests/test_ui.py: not imported
odoo/tests/test_module_operations.py: not imported
odoo/addons/base/tests/test_mail_examples.py: not imported
addons/l10n_it_edi/tests/test_res_partner.py: not imported
```
I don't know if Odoo did that on purpose but if they were planning on those tests being run, they won't, at least according to their documentation.