### PR TITLE
[FIX] ci: update flake8 repo URL, tox.ini and gh actions .yml

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -1,7 +1,5 @@
 name: build
 on:
-  # Trigger the workflow on push or pull request,
-  # but only for the main branch
   push:
     branches:
       - main
@@ -12,109 +10,22 @@ on:
       - main
 jobs:
   test:
-    name: ${{ matrix.name }}
     runs-on: ${{ matrix.os }}
     timeout-minutes: 30
     strategy:
       fail-fast: false
       matrix:
+        python: ['3.7', '3.8', '3.9', '3.10', '3.11']
+        os: [ubuntu-latest, windows-latest, macos-latest]
+        tox_env: ["py"]
         include:
-          # ubuntu
-          - name: 'py37-cover (ubuntu)'
-            python: '3.7'
-            toxpython: 'python3.7'
-            python_arch: 'x64'
-            tox_env: 'py37,report,codecov'
-            os: 'ubuntu-latest'
-          - name: 'py38-cover (ubuntu)'
-            python: '3.8'
-            toxpython: 'python3.8'
-            python_arch: 'x64'
-            tox_env: 'py38,report,codecov'
-            os: 'ubuntu-latest'
-          - name: 'py39-cover (ubuntu)'
-            python: '3.9'
-            toxpython: 'python3.9'
-            python_arch: 'x64'
-            tox_env: 'py39,report,codecov'
-            os: 'ubuntu-latest'
-          - name: 'py310-cover (ubuntu) + lint + build'
-            python: '3.10'
-            toxpython: 'python3.10'
-            python_arch: 'x64'
-            tox_env: 'py310,report,codecov,update-readme,lint,build'
-            os: 'ubuntu-latest'
-          - name: 'py311-dev-cover (ubuntu)'
-            python: '3.11-dev'
-            toxpython: 'python3.11'
-            python_arch: 'x64'
-            tox_env: 'py311,report,codecov'
-            os: 'ubuntu-latest'
+          - python: '3.10'
+            os: ubuntu-latest
+            tox_env: 'py,lint,update-readme,build'
+        exclude:
+          - python: '3.11'
+            os: windows-latest
 
-          # windows
-          - name: 'py37-cover (windows)'
-            python: '3.7'
-            toxpython: 'python3.7'
-            python_arch: 'x64'
-            tox_env: 'py37,report,codecov'
-            os: 'windows-latest'
-          - name: 'py38-cover (windows)'
-            python: '3.8'
-            toxpython: 'python3.8'
-            python_arch: 'x64'
-            tox_env: 'py38,report,codecov'
-            os: 'windows-latest'
-          - name: 'py39-cover (windows)'
-            python: '3.9'
-            toxpython: 'python3.9'
-            python_arch: 'x64'
-            tox_env: 'py39,report,codecov'
-            os: 'windows-latest'
-          - name: 'py310-cover (windows)'
-            python: '3.10'
-            toxpython: 'python3.10'
-            python_arch: 'x64'
-            tox_env: 'py310,report,codecov'
-            os: 'windows-latest'
-          # TOOD: Enable after github actions fix errors
-          # - name: 'py311-dev-cover (windows)'
-          #   python: '3.11-dev'
-          #   toxpython: 'python3.11'
-          #   python_arch: 'x64'
-          #   tox_env: 'py311,report,codecov'
-          #   os: 'windows-latest'
-
-          # macos
-          - name: 'py37-cover (macos)'
-            python: '3.7'
-            toxpython: 'python3.7'
-            python_arch: 'x64'
-            tox_env: 'py37,report,codecov'
-            os: 'macos-latest'
-          - name: 'py38-cover (macos)'
-            python: '3.8'
-            toxpython: 'python3.8'
-            python_arch: 'x64'
-            tox_env: 'py38,report,codecov'
-            os: 'macos-latest'
-          - name: 'py39-cover (macos)'
-            python: '3.9'
-            toxpython: 'python3.9'
-            python_arch: 'x64'
-            tox_env: 'py39,report,codecov'
-            os: 'macos-latest'
-          - name: 'py310-cover (macos)'
-            python: '3.10'
-            toxpython: 'python3.10'
-            python_arch: 'x64'
-            tox_env: 'py310,report,codecov'
-            os: 'macos-latest'
-          - name: 'py311-dev-cover (macos)'
-            python: '3.11-dev'
-            toxpython: 'python3.11'
-            python_arch: 'x64'
-            tox_env: 'py311,report,codecov'
-            os: 'macos-latest'
 
     steps:
     - name: Set git to not change EoL
@@ -126,34 +37,29 @@ jobs:
       uses: actions/cache@v3
       with:
         path: ~/.cache/pre-commit
-        key: ${{ runner.os }}-py${{ matrix.python }}-${{ matrix.python_arch }}-pre-commit
+        key: ${{ runner.os }}-py${{ matrix.python }}-pre-commit
     - uses: actions/checkout@v2
       with:
         fetch-depth: 0
     - uses: actions/setup-python@v4
       with:
         python-version: ${{ matrix.python }}
-        architecture: ${{ matrix.python_arch }}
+        architecture: 'x64'
         cache: 'pip'
     - name: install dependencies
       run: |
         python -mpip install --progress-bar=off -r test-requirements.txt
-        # virtualenv --version
         pip --version
-        # tox --version
         pip list --format=freeze
     - name: Test
-      env:
-        TOXPYTHON: '${{ matrix.toxpython }}'
-      run: |
-        tox -e ${{ matrix.tox_env }} -v
-    # TODO: Publish package only for signed tags
+      run: tox -e ${{ matrix.tox_env }} -v
+      # TODO: Publish package only for signed tags
     - name: Publish package
       if: github.event_name == 'push' && startsWith(github.ref, 'refs/tags') && contains(matrix.tox_env, 'build')
       run: |
         ls -lah dist/*
         python -m twine upload --verbose -u __token__ -p ${{ secrets.PYPI_API_TOKEN }} --repository-url https://upload.pypi.org/legacy/ dist/*
-    # TODO: Add GITHUB_RUN_ID.GITHUB_RUN_ATTEMPT.GITHUB_RUN_NUMBER to bumpversion to avoid duplicating upload versions or even the git sha
+    # TODO: Add GITHUB_RUN_ID.GITHUB_RUN_ATTEMPT.GITHUB_RUN_NUMBER to bumpversion to avoid duplicating upload versions or even the git sha
     # For now, feel free to uncomment this line of code to test things related to upload to pypi (test)
     # - name: TestPyPI publish package
     #   if: runner.os == 'Linux' && startsWith(matrix.tox_env, 'py39-cover')

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -75,7 +75,7 @@ repos:
         args:
           - --settings=.
         exclude: /__init__\.py$
-  - repo: https://gitlab.com/PyCQA/flake8
+  - repo: https://github.com/PyCQA/flake8
     rev: 3.9.2
     hooks:
       - id: flake8

--- a/tox.ini
+++ b/tox.ini
@@ -10,8 +10,6 @@ envlist =
     py311,
 
 [testenv]
-basepython =
-    {clean,build,report,codecov,lint}: {env:TOXPYTHON:python3}
 parallel_show_output=true
 setenv =
     PYTHONPATH={toxinidir}/tests
@@ -24,7 +22,7 @@ passenv =
 deps = -r{toxinidir}/test-requirements.txt
 usedevelop = true
 commands =
-    pytest --cov-append -s --cov --cov-report=term-missing -vv {posargs:}
+    pytest --cov-append -s --cov --cov-report=term-missing --cov-report=html -vv {posargs:}
 
 
 [testenv:update-readme]
@@ -61,40 +59,7 @@ commands =
     # Testing the package is importing the dependencies well
     python -c '''import sys, os;from oca_pre_commit_hooks import cli,cli_po;os.chdir("dist");sys.argv = ["", "--list-msgs", "--no-exit"];cli.main();cli_po.main()'''
 
-[testenv:codecov]
-deps =
-    codecov
-skip_install = true
-commands =
-    codecov []
-
-[testenv:report]
-deps = coverage
-skip_install = true
-setenv =
-    COVERAGE_FILE = {toxinidir}/.coverage
-commands =
-    # Workaround https://github.com/tox-dev/tox/issues/1571
-    python -c 'from glob import glob; import subprocess; [subprocess.check_call(["coverage", "combine", "--keep", i]) for i in glob(".coverage.*")]'
-    coverage report --fail-under=0  # The next command will fail instead but will allow to see the html report
-    coverage html
-
 [testenv:clean]
 commands = coverage erase
 skip_install = true
 deps = coverage
-
-[testenv:py37]
-basepython = {env:TOXPYTHON:python3.7}
-
-[testenv:py38]
-basepython = {env:TOXPYTHON:python3.8}
-
-[testenv:py39]
-basepython = {env:TOXPYTHON:python3.9}
-
-[testenv:py310]
-basepython = {env:TOXPYTHON:python3.10}
-
-[testenv:py311]
-basepython = {env:TOXPYTHON:python3.11}


### PR DESCRIPTION
Repository was moved from gitlab to github. This fixes `tox -e lint` which as of right now hangs indefinitely (asks username for gitlab.com).