### PR TITLE
[IMP] README: Added a section on configuration (#37)

### DIFF
--- a/README.md
+++ b/README.md
@@ -219,19 +219,16 @@ be disabled.
 usage: oca-checks-odoo-module [-h] [--no-verbose] [--no-exit] [--disable DISABLE] [--enable ENABLE] [--config CONFIG] [--list-msgs] [files_or_modules ...]
 
 positional arguments:
-  files_or_modules      Odoo __manifest__.py paths or Odoo module paths.
+ files_or_modules Odoo __manifest__.py paths or Odoo module paths.
 
 options:
-  -h, --help            show this help message and exit
-  --no-verbose          If enabled so disable verbose mode.
-  --no-exit             If enabled so it will not call exit.
-  --disable DISABLE, -d DISABLE
-                        Disable the checker with the given 'check-name', separated by commas.
-  --enable ENABLE, -e ENABLE
-                        Enable the checker with the given 'check-name', separated by commas. Default: All checks are enabled by default
-  --config CONFIG, -c CONFIG
-                        Path to a configuration file (default: .oca_hooks.cfg)
-  --list-msgs           List all currently enabled messages.
+ -h, --help show this help message and exit
+ --no-verbose If enabled so disable verbose mode.
+ --no-exit If enabled so it will not call exit.
+ --disable DISABLE, -d DISABLE Disable the checker with the given 'check-name', separated by commas.
+ --enable ENABLE, -e ENABLE Enable the checker with the given 'check-name', separated by commas. Default: All checks are enabled by default
+ --config CONFIG, -c CONFIG Path to a configuration file (default: .oca_hooks.cfg)
+ --list-msgs List all currently enabled messages.
 
 ```
 
@@ -245,19 +242,16 @@ options:
 usage: oca-checks-po [-h] [--no-verbose] [--no-exit] [--disable DISABLE] [--enable ENABLE] [--config CONFIG] [--list-msgs] [po_files ...]
 
 positional arguments:
-  po_files              PO files.
+ po_files PO files.
 
 options:
-  -h, --help            show this help message and exit
-  --no-verbose          If enabled so disable verbose mode.
-  --no-exit             If enabled so it will not call exit.
-  --disable DISABLE, -d DISABLE
-                        Disable the checker with the given 'check-name', separated by commas.
-  --enable ENABLE, -e ENABLE
-                        Enable the checker with the given 'check-name', separated by commas. Default: All checks are enabled by default
-  --config CONFIG, -c CONFIG
-                        Path to a configuration file (default: .oca_hooks.cfg)
-  --list-msgs           List all currently enabled messages.
+ -h, --help show this help message and exit
+ --no-verbose If enabled so disable verbose mode.
+ --no-exit If enabled so it will not call exit.
+ --disable DISABLE, -d DISABLE Disable the checker with the given 'check-name', separated by commas.
+ --enable ENABLE, -e ENABLE Enable the checker with the given 'check-name', separated by commas. Default: All checks are enabled by default
+ --config CONFIG, -c CONFIG Path to a configuration file (default: .oca_hooks.cfg)
+ --list-msgs List all currently enabled messages.
 
 ```
 

--- a/README.md
+++ b/README.md
@@ -73,7 +73,35 @@ The position of the comment it is not relative to the line that throw the check
 
 It disable the entire file
 
+# Configuration
+Behavior can be configured through several methods and as of now only consists of enabling/disabling checks.
 
+## Enabling or Disabling Checks
+Each available hook consists of multiple checks which can be enabled/disabled using any of the following methods (ordered by priority):
+
+1. As an argument e.g., `oca-checks-odoo --enable=check-to-enable --disable=check-to-disable1,check-to-disable2`
+2. Using environment variables `OCA_HOOKS_ENABLE` or `OCA_HOOKS_DISABLE` e.g., `export OCA_HOOKS_ENABLE=check1,check2`
+3. A configuration file. The path to it can be specified with the argument `--config`. Alternatively a file named `.oca_hooks.cfg`
+will be looked for (by default) in the following locations (in order):
+   1. Current working directory
+   2. Repo's root
+   3. User's home
+
+### Using a Configuration File
+To enable or disable checks using a configuration file, add a `disable` or `enable` key under the `MESSAGES_CONTROL` section.
+For example:
+```
+[MESSAGES_CONTROL]
+enable=check-enable1,check-enable2
+disable=check-to-disable
+```
+
+As stated before, each source has a certain priority. This means that if the environment variable `OCA_HOOKS_ENABLE=check1`
+exists, the configuration file above would not have any effect when it comes to enabling checks, and the only enabled
+check will be `check1`.
+
+However, if `OCA_HOOKS_DISABLE` is not set, the configuration file will still have an effect and `check-to-disable` will
+be disabled.
 
 [//]: # (start-checks)
 
@@ -188,10 +216,7 @@ It disable the entire file
 
 # Help
 ```bash
-usage: oca-checks-odoo-module [-h] [--no-verbose] [--no-exit]
-                              [--disable DISABLE] [--enable ENABLE]
-                              [--config CONFIG] [--list-msgs]
-                              [files_or_modules ...]
+usage: oca-checks-odoo-module [-h] [--no-verbose] [--no-exit] [--disable DISABLE] [--enable ENABLE] [--config CONFIG] [--list-msgs] [files_or_modules ...]
 
 positional arguments:
   files_or_modules      Odoo __manifest__.py paths or Odoo module paths.
@@ -201,14 +226,11 @@ options:
   --no-verbose          If enabled so disable verbose mode.
   --no-exit             If enabled so it will not call exit.
   --disable DISABLE, -d DISABLE
-                        Disable the checker with the given 'check-name',
-                        separated by commas.
+                        Disable the checker with the given 'check-name', separated by commas.
   --enable ENABLE, -e ENABLE
-                        Enable the checker with the given 'check-name',
-                        separated by commas. Default: All checks are enabled
-                        by default
+                        Enable the checker with the given 'check-name', separated by commas. Default: All checks are enabled by default
   --config CONFIG, -c CONFIG
-                        Path to a configuration file
+                        Path to a configuration file (default: .oca_hooks.cfg)
   --list-msgs           List all currently enabled messages.
 
 ```
@@ -220,9 +242,7 @@ options:
 
 # Help PO
 ```bash
-usage: oca-checks-po [-h] [--no-verbose] [--no-exit] [--disable DISABLE]
-                     [--enable ENABLE] [--config CONFIG] [--list-msgs]
-                     [po_files ...]
+usage: oca-checks-po [-h] [--no-verbose] [--no-exit] [--disable DISABLE] [--enable ENABLE] [--config CONFIG] [--list-msgs] [po_files ...]
 
 positional arguments:
   po_files              PO files.
@@ -232,14 +252,11 @@ options:
   --no-verbose          If enabled so disable verbose mode.
   --no-exit             If enabled so it will not call exit.
   --disable DISABLE, -d DISABLE
-                        Disable the checker with the given 'check-name',
-                        separated by commas.
+                        Disable the checker with the given 'check-name', separated by commas.
   --enable ENABLE, -e ENABLE
-                        Enable the checker with the given 'check-name',
-                        separated by commas. Default: All checks are enabled
-                        by default
+                        Enable the checker with the given 'check-name', separated by commas. Default: All checks are enabled by default
   --config CONFIG, -c CONFIG
-                        Path to a configuration file
+                        Path to a configuration file (default: .oca_hooks.cfg)
   --list-msgs           List all currently enabled messages.
 
 ```

--- a/src/oca_pre_commit_hooks/global_parser.py
+++ b/src/oca_pre_commit_hooks/global_parser.py
@@ -48,7 +48,12 @@ class GlobalParser(argparse.ArgumentParser):
                 "Default: All checks are enabled by default"
             ),
         )
-        self.add_argument("--config", "-c", type=argparse.FileType("r"), help="Path to a configuration file")
+        self.add_argument(
+            "--config",
+            "-c",
+            type=argparse.FileType("r"),
+            help=f"Path to a configuration file (default: {CONFIG_NAME})",
+        )
         self.add_argument(
             "--list-msgs", default=False, action="store_true", help="List all currently enabled messages."
         )

--- a/tests/test_checks.py
+++ b/tests/test_checks.py
@@ -1,6 +1,7 @@
 # pylint: disable=duplicate-code,useless-suppression
 import glob
 import os
+import re
 import subprocess
 import sys
 import unittest
@@ -95,6 +96,9 @@ class TestChecksWithFiles(common.ChecksCommon):
             sys.stdout.encoding
         )
         help_content = f"# Help\n```bash\n{help_content}\n```"
+        # remove extra spaces
+        help_content = re.sub(r"\n(      )+", " ", help_content)
+        help_content = re.sub(r"( )+", " ", help_content)
         new_readme = self.re_replace("[//]: # (start-help)", "[//]: # (end-help)", help_content, new_readme)
 
         all_check_errors = self.checks_run(sorted(self.file_paths), no_exit=True, no_verbose=False)

--- a/tests/test_checks_po.py
+++ b/tests/test_checks_po.py
@@ -1,5 +1,6 @@
 import glob
 import os
+import re
 import subprocess
 import sys
 import unittest
@@ -65,6 +66,9 @@ class TestChecksPO(common.ChecksCommon):
             sys.stdout.encoding
         )
         help_content = f"# Help PO\n```bash\n{help_content}\n```"
+        # remove extra spaces
+        help_content = re.sub(r"\n(      )+", " ", help_content)
+        help_content = re.sub(r"( )+", " ", help_content)
         new_readme = self.re_replace("[//]: # (start-help-po)", "[//]: # (end-help-po)", help_content, new_readme)
 
         all_check_errors = self.checks_run(self.file_paths, no_exit=True, no_verbose=False)


### PR DESCRIPTION
Fix #37 

The README has been modified to include documentation on how to use the configuration file (.oca_hooks.cfg) to enable/disable messages.

The help message for the config file now includes info on the default lookup location as well.