### PR TITLE
[IMP] add xml-oe-structure-missing-id check

### DIFF
--- a/README.md
+++ b/README.md
@@ -131,6 +131,11 @@ be disabled.
 * Check xml-not-valid-char-link
         The resource in in src/href contains a not valid character.
 
+* Check xml-oe-structure-missing-id
+
+        Ensure all tags with class 'oe_structure' have an ID. For more information on the rationale, see:
+        https://github.com/OCA/odoo-pre-commit-hooks/issues/27
+
 * Check xml-redundant-module-name
 
         If the module is called "module_a" and the xmlid is
@@ -315,7 +320,7 @@ options:
 
  * xml-deprecated-qweb-directive
 
-    - https://github.com/OCA/odoo-pre-commit-hooks/blob/v0.0.25/test_repo/test_module/website_templates.xml#L14 Deprecated QWeb directive `"t-field-options"`. Use `"t-options"` instead
+    - https://github.com/OCA/odoo-pre-commit-hooks/blob/v0.0.25/test_repo/test_module/website_templates.xml#L21 Deprecated QWeb directive `"t-field-options"`. Use `"t-options"` instead
     - https://github.com/OCA/odoo-pre-commit-hooks/blob/v0.0.25/test_repo/test_module/website_templates.xml#L7 Deprecated QWeb directive `"t-esc-options"`. Use `"t-options"` instead
 
  * xml-deprecated-tree-attribute
@@ -337,8 +342,13 @@ options:
 
  * xml-not-valid-char-link
 
-    - https://github.com/OCA/odoo-pre-commit-hooks/blob/v0.0.25/test_repo/test_module/website_templates.xml#L21 The resource in in src/href contains a not valid character
-    - https://github.com/OCA/odoo-pre-commit-hooks/blob/v0.0.25/test_repo/test_module/website_templates.xml#L23 The resource in in src/href contains a not valid character
+    - https://github.com/OCA/odoo-pre-commit-hooks/blob/v0.0.25/test_repo/test_module/website_templates.xml#L34 The resource in in src/href contains a not valid character
+    - https://github.com/OCA/odoo-pre-commit-hooks/blob/v0.0.25/test_repo/test_module/website_templates.xml#L36 The resource in in src/href contains a not valid character
+
+ * xml-oe-structure-missing-id
+
+    - https://github.com/OCA/odoo-pre-commit-hooks/blob/v0.0.25/test_repo/test_module/website_templates.xml#L25 Consider removing the class 'oe_structure' or adding an id to the tag
+    - https://github.com/OCA/odoo-pre-commit-hooks/blob/v0.0.25/test_repo/test_module/website_templates.xml#L9 Consider removing the class 'oe_structure' or adding an id to the tag
 
  * xml-redundant-module-name
 

--- a/test_repo/test_module/website_templates.xml
+++ b/test_repo/test_module/website_templates.xml
@@ -6,6 +6,13 @@
         <div>
             <span t-esc="price" t-esc-options='{"widget": "monetary"}'/>
         </div>
+        <section class="oe_structure">
+            <p>Customize this!</p>
+        </section>
+        <div class="oe_structure_gotcha">
+            <span>I did nothing wrong :)</span>
+        </div>
+        <div class="d-flex fake_oe_structure"/>
     </template>
 
     <!-- Deprecated QWeb directive "t-field-options". -->
@@ -13,6 +20,12 @@
         <div>
             <span t-field="line.image" t-field-options='{"widget": "image"}'/>
         </div>
+        <div id="correct_oe_structure" class="oe_structure"/>
+        <body>
+            <div class="oe_structure px-1 py-2">
+                <span>Hello</span>
+            </div>
+        </body>
     </template>
 
     <template id="assets_backend" name="test_module_widget" inherit_id="web.assets_backend">

--- a/tests/test_checks.py
+++ b/tests/test_checks.py
@@ -35,6 +35,7 @@ EXPECTED_ERRORS = {
     "xml-syntax-error": 2,
     "xml-view-dangerous-replace-low-priority": 6,
     "xml-xpath-translatable-item": 4,
+    "xml-oe-structure-missing-id": 2,
 }
 
 


### PR DESCRIPTION
Closes #27.

This checks generates a message whenever a tag with 'oe_structure' in its classes has no id attribute.