### PR TITLE
[REF] improve XPath expressions, compile them only once, fix false negative

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -22,6 +22,9 @@ jobs:
           - python: '3.10'
             os: ubuntu-latest
             tox_env: 'py,lint,update-readme,build'
+          - python: '3.10'
+            os: ubuntu-latest
+            tox_env: 'cprofile'
         exclude:
           - python: '3.11'
             os: windows-latest

--- a/README.md
+++ b/README.md
@@ -304,6 +304,7 @@ options:
     - https://github.com/OCA/odoo-pre-commit-hooks/blob/v0.0.25/test_repo/broken_module/model_view_odoo.xml#L3 Use `<odoo>` instead of `<odoo><data>` or use `<odoo noupdate="1">` instead of `<odoo><data noupdate="1">`
     - https://github.com/OCA/odoo-pre-commit-hooks/blob/v0.0.25/test_repo/broken_module/model_view_odoo2.xml#L3 Use `<odoo>` instead of `<odoo><data>` or use `<odoo noupdate="1">` instead of `<odoo><data noupdate="1">`
     - https://github.com/OCA/odoo-pre-commit-hooks/blob/v0.0.25/test_repo/broken_module/skip_xml_check.xml#L5 Use `<odoo>` instead of `<odoo><data>` or use `<odoo noupdate="1">` instead of `<odoo><data noupdate="1">`
+    - https://github.com/OCA/odoo-pre-commit-hooks/blob/v0.0.25/test_repo/broken_module/skip_xml_check_2.xml#L3 Use `<odoo>` instead of `<odoo><data>` or use `<odoo noupdate="1">` instead of `<odoo><data noupdate="1">`
     - https://github.com/OCA/odoo-pre-commit-hooks/blob/v0.0.25/test_repo/test_module/model_view.xml#L3 Use `<odoo>` instead of `<odoo><data>` or use `<odoo noupdate="1">` instead of `<odoo><data noupdate="1">`
 
  * xml-deprecated-openerp-node

--- a/src/oca_pre_commit_hooks/checks_odoo_module_xml.py
+++ b/src/oca_pre_commit_hooks/checks_odoo_module_xml.py
@@ -11,6 +11,35 @@ DFLT_DEPRECATED_TREE_ATTRS = ["colors", "fonts", "string"]
 
 
 class ChecksOdooModuleXML:
+    xpath_deprecated_data = etree.XPath("/odoo[count(./*) < 2]/data|/openerp[count(./*) < 2]/data")
+    xpath_view_replaces = etree.XPath(
+        ".//field[@name='name' and @position='replace'][1] | .//*[@position='replace'][1]"
+    )
+    xpath_record_wid = etree.XPath("/odoo//record[@id] | /openerp//record[@id]")
+    xpath_view_arch_xml = etree.XPath("field[@name='arch' and @type='xml'][1]")
+    xpath_ir_fields = etree.XPath("field[@name='name' or @name='user_id']")
+    xpath_template = etree.XPath("/odoo//template|/openerp//template")
+    xpath_char_links = etree.XPath(".//link[@href]|.//script[@src]")
+    xpath_view_priority = etree.XPath("field[@name='priority'][1]")
+    xpath_field_name = etree.XPath("field[@name='name'][1]")
+    xpath_record_fields_wname = etree.XPath("field[@name]")
+    xpath_comment = etree.XPath("//comment()")
+    xpath_openerp = etree.XPath("/openerp")
+    xpath_xpath = etree.XPath("//xpath")
+
+    tree_deprecate_attrs = {"string", "colors", "fonts"}
+    xpath_tree_deprecated = etree.XPath(f'.//tree[{"|".join(f"@{a}" for a in tree_deprecate_attrs)}]')
+
+    qweb_deprecated_directives = {
+        "t-esc-options",
+        "t-field-options",
+        "t-raw-options",
+    }
+    qweb_deprecated_attrs = "|".join(f"@{d}" for d in qweb_deprecated_directives)
+    xpath_qweb_deprecated = etree.XPath(
+        f"/odoo//template//*[{qweb_deprecated_attrs}] | " f"/openerp//template//*[{qweb_deprecated_attrs}]"
+    )
+
     def __init__(self, manifest_datas, module_name, enable, disable):
         self.module_name = module_name
         self.enable = enable
@@ -43,7 +72,7 @@ class ChecksOdooModuleXML:
         e.g. <!-- oca-hooks:disable=check-name -->
         """
         all_checks_disabled = set()
-        for comment_node in node.xpath("//comment()"):
+        for comment_node in self.xpath_comment(node):
             checks_disabled, use_deprecated = utils.checks_disabled(comment_node.text)
             all_checks_disabled |= set(checks_disabled)
             if use_deprecated:
@@ -58,23 +87,23 @@ class ChecksOdooModuleXML:
         disable_node = manifest_data["disabled_checks"]
         return utils.is_message_enabled(checks, self.enable, self.disable, disable_node)
 
-    @staticmethod
-    def _get_priority(view):
+    @classmethod
+    def _get_priority(cls, view):
         try:
-            priority_node = view.xpath("field[@name='priority'][1]")[0]
+            priority_node = cls.xpath_view_priority(view)[0]
             return int(priority_node.get("eval", priority_node.text) or 0)
         except (IndexError, ValueError):
             # IndexError: If the field is not found
             # ValueError: If the value found is not valid integer
             return 0
 
-    @staticmethod
-    def _is_replaced_field(view):
+    @classmethod
+    def _is_replaced_field(cls, view):
         try:
-            arch = view.xpath("field[@name='arch' and @type='xml'][1]")[0]
+            arch = cls.xpath_view_arch_xml(view)[0]
         except IndexError:
             return False
-        replaces = arch.xpath(".//field[@name='name' and @position='replace'][1] | .//*[@position='replace'][1]")
+        replaces = cls.xpath_view_replaces(arch)
         return bool(replaces)
 
     # Not set only_required_for_checks because of the calls to visit_xml_record... methods
@@ -95,7 +124,7 @@ class ChecksOdooModuleXML:
         xmlids_section = defaultdict(list)
         xml_fields = defaultdict(list)
         for manifest_data in self.manifest_datas:
-            for record in manifest_data["node"].xpath("/odoo//record[@id] | /openerp//record[@id]"):
+            for record in self.xpath_record_wid(manifest_data["node"]):
                 record_id = record.get("id")
 
                 if self.is_message_enabled("xml-duplicate-record-id", manifest_data):
@@ -108,7 +137,7 @@ class ChecksOdooModuleXML:
 
                 # fields_duplicated
                 if self.is_message_enabled("xml-duplicate-fields", manifest_data):
-                    for field in record.xpath("field[@name]"):
+                    for field in self.xpath_record_fields_wname(record):
                         xml_fields[(field.get("name"), field.getparent())].append((manifest_data, field))
 
                 # call "visit_xml_record_*" methods to re-use the same node xpath loop
@@ -193,10 +222,8 @@ class ChecksOdooModuleXML:
             )
 
         # deprecated_tree_attribute
-        deprecate_attrs = {"string", "colors", "fonts"}
-        xpath = f".//tree[{'|'.join(f'@{a}' for a in deprecate_attrs)}]"
-        for deprecate_attr_node in record.xpath(xpath):
-            deprecate_attr_str = ",".join(set(deprecate_attr_node.attrib.keys()) & deprecate_attrs)
+        for deprecate_attr_node in self.xpath_tree_deprecated(record):
+            deprecate_attr_str = ",".join(set(deprecate_attr_node.attrib.keys()) & self.tree_deprecate_attrs)
             self.checks_errors["xml-deprecated-tree-attribute"].append(
                 f'{manifest_data["filename_short"]}:{deprecate_attr_node.sourceline} '
                 f'Deprecated "<tree {deprecate_attr_str}=..."'
@@ -228,7 +255,7 @@ class ChecksOdooModuleXML:
         # xml_dangerous_filter_wo_user
         if record.get("model") != "ir.filters":
             return
-        ir_filter_fields = record.xpath("field[@name='name' or @name='user_id']")
+        ir_filter_fields = self.xpath_ir_fields(record)
         # if exists field="name" then is a new record
         # then should be field="user_id" too
         if ir_filter_fields and len(ir_filter_fields) == 1:
@@ -243,16 +270,15 @@ class ChecksOdooModuleXML:
         for manifest_data in self.manifest_datas:
             if not self.is_message_enabled("xml-not-valid-char-link", manifest_data):
                 continue
-            for name, attr in (("link", "href"), ("script", "src")):
-                nodes = manifest_data["node"].xpath(f".//{name}[@{attr}]")
-                for node in nodes:
-                    resource = node.get(attr, "")
-                    ext = os.path.splitext(os.path.basename(resource))[1]
-                    if resource.startswith("/") and not re.search("^[.][a-zA-Z]+$", ext):
-                        self.checks_errors["xml-not-valid-char-link"].append(
-                            f'{manifest_data["filename_short"]}:{node.sourceline} '
-                            f"The resource in in src/href contains a not valid character"
-                        )
+
+            for node in self.xpath_char_links(manifest_data["node"]):
+                resource = node.get("href", "") or node.get("src", "")
+                ext = os.path.splitext(os.path.basename(resource))[1]
+                if resource.startswith("/") and not re.search("^[.][a-zA-Z]+$", ext):
+                    self.checks_errors["xml-not-valid-char-link"].append(
+                        f'{manifest_data["filename_short"]}:{node.sourceline} '
+                        f"The resource in in src/href contains a not valid character"
+                    )
 
     @utils.only_required_for_checks("xml-dangerous-qweb-replace-low-priority")
     def check_xml_dangerous_qweb_replace_low_priority(self):
@@ -261,7 +287,7 @@ class ChecksOdooModuleXML:
         for manifest_data in self.manifest_datas:
             if not self.is_message_enabled("xml-dangerous-qweb-replace-low-priority", manifest_data):
                 continue
-            for template in manifest_data["node"].xpath("/odoo//template|/openerp//template"):
+            for template in self.xpath_template(manifest_data["node"]):
                 try:
                     priority = int(template.get("priority"))
                 except (ValueError, TypeError):
@@ -284,20 +310,13 @@ class ChecksOdooModuleXML:
         for manifest_data in self.manifest_datas:
             if not self.is_message_enabled("xml-deprecated-data-node", manifest_data):
                 continue
-            for odoo_node in manifest_data["node"].xpath("/odoo|/openerp"):
-                children_count = 0
-                for children_count, _ in enumerate(odoo_node.iterchildren(), start=1):
-                    if children_count == 2:
-                        # Only needs to know if there are more than one child
-                        break
-                data_nodes = odoo_node.xpath("./data")
-                if children_count == 1 and len(data_nodes) == 1:
-                    # TODO: Add autofix option
-                    self.checks_errors["xml-deprecated-data-node"].append(
-                        f'{manifest_data["filename_short"]}:{data_nodes[0].sourceline} '
-                        'Use `<odoo>` instead of `<odoo><data>` or use `<odoo noupdate="1">` '
-                        'instead of `<odoo><data noupdate="1">`'
-                    )
+            for data_node in self.xpath_deprecated_data(manifest_data["node"]):
+                # TODO: Add autofix option
+                self.checks_errors["xml-deprecated-data-node"].append(
+                    f'{manifest_data["filename_short"]}:{data_node.sourceline} '
+                    'Use `<odoo>` instead of `<odoo><data>` or use `<odoo noupdate="1">` '
+                    'instead of `<odoo><data noupdate="1">`'
+                )
 
     @utils.only_required_for_checks("xml-deprecated-openerp-node")
     def check_xml_deprecated_openerp_node(self):
@@ -306,7 +325,7 @@ class ChecksOdooModuleXML:
         for manifest_data in self.manifest_datas:
             if not self.is_message_enabled("xml-deprecated-openerp-node", manifest_data):
                 continue
-            for openerp_node in manifest_data["node"].xpath("/openerp"):
+            for openerp_node in self.xpath_openerp(manifest_data["node"]):
                 # TODO: Add autofix option
                 self.checks_errors["xml-deprecated-openerp-node"].append(
                     f'{manifest_data["filename_short"]}:{openerp_node.sourceline} ' "Deprecated <openerp> xml node"
@@ -316,19 +335,11 @@ class ChecksOdooModuleXML:
     def check_xml_deprecated_qweb_directive(self):
         """* Check xml-deprecated-qweb-directive
         for use of deprecated QWeb directives t-*-options"""
-        deprecated_directives = {
-            "t-esc-options",
-            "t-field-options",
-            "t-raw-options",
-        }
-        deprecated_attrs = "|".join(f"@{d}" for d in deprecated_directives)
-        xpath = f"/odoo//template//*[{deprecated_attrs}] | " f"/openerp//template//*[{deprecated_attrs}]"
-
         for manifest_data in self.manifest_datas:
             if not self.is_message_enabled("xml-deprecated-qweb-directive", manifest_data):
                 continue
-            for node in manifest_data["node"].xpath(xpath):
-                directive_str = ", ".join(set(node.attrib) & deprecated_directives)
+            for node in self.xpath_qweb_deprecated(manifest_data["node"]):
+                directive_str = ", ".join(set(node.attrib) & self.qweb_deprecated_directives)
                 self.checks_errors["xml-deprecated-qweb-directive"].append(
                     f'{manifest_data["filename_short"]}:{node.sourceline} '
                     f'Deprecated QWeb directive `"{directive_str}"`. Use `"t-options"` instead'
@@ -341,7 +352,7 @@ class ChecksOdooModuleXML:
         It could raise `ValueError` exception if the language is changed.
         """
         for manifest_data in self.manifest_datas:
-            for xpath_node in manifest_data["node"].xpath("//xpath"):
+            for xpath_node in self.xpath_xpath(manifest_data["node"]):
                 node_expr = (xpath_node.get("expr") or "").replace(" ", "")
                 if "[contains(text()" in node_expr or "[text()=" in node_expr:
                     self.checks_errors["xml-xpath-translatable-item"].append(

--- a/tests/test_checks.py
+++ b/tests/test_checks.py
@@ -24,7 +24,7 @@ EXPECTED_ERRORS = {
     "xml-create-user-wo-reset-password": 1,
     "xml-dangerous-filter-wo-user": 1,
     "xml-dangerous-qweb-replace-low-priority": 9,
-    "xml-deprecated-data-node": 7,
+    "xml-deprecated-data-node": 8,
     "xml-deprecated-openerp-node": 4,
     "xml-deprecated-qweb-directive": 2,
     "xml-deprecated-tree-attribute": 3,

--- a/tests/test_profiling.py
+++ b/tests/test_profiling.py
@@ -1,0 +1,77 @@
+import sys
+from contextlib import contextmanager
+from cProfile import Profile
+from glob import glob
+from os import environ
+from os.path import dirname, join, realpath
+from pstats import Stats
+from sys import stdout
+from unittest import TestCase, skipUnless
+
+import oca_pre_commit_hooks
+from . import common
+from .test_checks import EXPECTED_ERRORS as MODULES_ERRORS
+from .test_checks_po import EXPECTED_ERRORS as PO_ERRORS
+
+
+@contextmanager
+def cprofile():
+    profiler = Profile()
+
+    profiler.enable()
+    yield
+    profiler.disable()
+
+    stats = Stats(profiler, stream=stdout)
+    stats.strip_dirs()
+    stats.sort_stats("cumtime")
+    stats.print_stats()
+
+
+@skipUnless(environ.get("PROFILING"), "Profiling not enabled")
+class TestProfiling(TestCase):
+    @staticmethod
+    def manifests_from_repo(repo: str):
+        return glob(join(repo, "**", "__openerp__.py"), recursive=True) + glob(
+            join(repo, "**", "__manifest__.py"), recursive=True
+        )
+
+    @staticmethod
+    def pofiles_from_repo(repo: str):
+        po_glob_pattern = join(repo, "**", "*.po")
+        pot_glob_pattern = f"{po_glob_pattern}t"
+
+        return glob(po_glob_pattern, recursive=True) + glob(pot_glob_pattern, recursive=True)
+
+    @classmethod
+    def setUpClass(cls):
+        test_repo_path = join(dirname(dirname(realpath(__file__))), "test_repo")
+
+        cls.module_files = cls.manifests_from_repo(test_repo_path)
+        cls.po_files = cls.pofiles_from_repo(test_repo_path)
+
+    def test_profile_checks_module(self):
+        checks_module_run = oca_pre_commit_hooks.cli.main
+        sys.argv = ["", "--no-exit", "--no-verbose"] + self.module_files
+        with cprofile():
+            errors = checks_module_run()
+
+        self.assertDictEqual(common.ChecksCommon.get_count_code_errors(errors), MODULES_ERRORS)
+
+    def test_profile_checks_po(self):
+        checks_po_run = oca_pre_commit_hooks.cli_po.main
+        sys.argv = ["", "--no-exit", "--no-verbose"] + self.po_files
+        with cprofile():
+            errors = checks_po_run()
+
+        self.assertDictEqual(common.ChecksCommon.get_count_code_errors(errors), PO_ERRORS)
+
+    @skipUnless(environ.get("PROFILING_TEST_REPO"), "No custom repository set for profiling")
+    def test_profile_checks_module_custom(self):
+        manifests = self.manifests_from_repo(environ.get("PROFILING_TEST_REPO"))
+        checks_module_run = oca_pre_commit_hooks.cli.main
+        sys.argv = ["", "--no-exit", "--no-verbose"] + manifests
+
+        print(f"Running oca-checks-odoo-module on {len(manifests)} manifests")
+        with cprofile():
+            checks_module_run()

--- a/tox.ini
+++ b/tox.ini
@@ -24,6 +24,11 @@ usedevelop = true
 commands =
     pytest --cov-append -s --cov --cov-report=term-missing --cov-report=html -vv {posargs:}
 
+[testenv:cprofile]
+setenv =
+    PROFILING=yes
+commands =
+    pytest -vv -rA {posargs:-k test_profile_checks}
 
 [testenv:update-readme]
 basepython = {env:TOXPYTHON:python3.10}


### PR DESCRIPTION
Added simple profiling test cases to get insights into the program
flow and possible bottlenecks of the system. The profiling
can be done on user-repositories with the following command:

`PROFILING_TEST_REPO=path/to/repo tox -e cprofile`

--------

* Some XPath expressions were improved to offload work from python code

* Similar to regex, xpath expressions are compiled at the class level and
  reused by checks, this means they are only compiled once instead of
  multiple times. More info:https://lxml.de/xpathxslt.html#the-xpath-class

* There was a false negative in test_repo/broken_module/skip_xml_check2.xml:3,
  xml-data-deprecated-node should be raised but was not, this was discovered
  when improving the xpath expressions. Apparently the previous method
  (using iterchildren) also counted comments in.