### PR TITLE
[FIX] oe-structure-missing-id: change constraints, add docs

### DIFF
--- a/README.md
+++ b/README.md
@@ -330,7 +330,7 @@ options:
 
  * xml-deprecated-qweb-directive
 
-    - https://github.com/OCA/odoo-pre-commit-hooks/blob/v0.0.27/test_repo/test_module/website_templates.xml#L21 Deprecated QWeb directive `"t-field-options"`. Use `"t-options"` instead
+    - https://github.com/OCA/odoo-pre-commit-hooks/blob/v0.0.27/test_repo/test_module/website_templates.xml#L20 Deprecated QWeb directive `"t-field-options"`. Use `"t-options"` instead
     - https://github.com/OCA/odoo-pre-commit-hooks/blob/v0.0.27/test_repo/test_module/website_templates.xml#L7 Deprecated QWeb directive `"t-esc-options"`. Use `"t-options"` instead
 
  * xml-deprecated-tree-attribute
@@ -352,13 +352,17 @@ options:
 
  * xml-not-valid-char-link
 
-    - https://github.com/OCA/odoo-pre-commit-hooks/blob/v0.0.27/test_repo/test_module/website_templates.xml#L34 The resource in in src/href contains a not valid character
-    - https://github.com/OCA/odoo-pre-commit-hooks/blob/v0.0.27/test_repo/test_module/website_templates.xml#L36 The resource in in src/href contains a not valid character
+    - https://github.com/OCA/odoo-pre-commit-hooks/blob/v0.0.27/test_repo/test_module/website_templates.xml#L39 The resource in in src/href contains a not valid character
+    - https://github.com/OCA/odoo-pre-commit-hooks/blob/v0.0.27/test_repo/test_module/website_templates.xml#L41 The resource in in src/href contains a not valid character
 
  * xml-oe-structure-missing-id
 
-    - https://github.com/OCA/odoo-pre-commit-hooks/blob/v0.0.27/test_repo/test_module/website_templates.xml#L25 Consider removing the class 'oe_structure' or adding an id to the tag
-    - https://github.com/OCA/odoo-pre-commit-hooks/blob/v0.0.27/test_repo/test_module/website_templates.xml#L9 Consider removing the class 'oe_structure' or adding an id to the tag
+    - https://github.com/OCA/odoo-pre-commit-hooks/blob/v0.0.27/test_repo/test_module/website_templates.xml#L13 Consider removing the class 'oe_structure' or adding a proper id to the tag. The id must contain 'oe_structure'
+    - https://github.com/OCA/odoo-pre-commit-hooks/blob/v0.0.27/test_repo/test_module/website_templates.xml#L24 Consider removing the class 'oe_structure' or adding a proper id to the tag. The id must contain 'oe_structure'
+    - https://github.com/OCA/odoo-pre-commit-hooks/blob/v0.0.27/test_repo/test_module/website_templates.xml#L27 Consider removing the class 'oe_structure' or adding a proper id to the tag. The id must contain 'oe_structure'
+    - https://github.com/OCA/odoo-pre-commit-hooks/blob/v0.0.27/test_repo/test_module/website_templates.xml#L30 Consider removing the class 'oe_structure' or adding a proper id to the tag. The id must contain 'oe_structure'
+    - https://github.com/OCA/odoo-pre-commit-hooks/blob/v0.0.27/test_repo/test_module/website_templates.xml#L9 Consider removing the class 'oe_structure' or adding a proper id to the tag. The id must contain 'oe_structure'
+    - https://github.com/OCA/odoo-pre-commit-hooks/blob/v0.0.27/test_repo/test_module/website_templates_disable.xml#L21 Consider removing the class 'oe_structure' or adding a proper id to the tag. The id must contain 'oe_structure'
 
  * xml-redundant-module-name
 

--- a/docs/conf.py
+++ b/docs/conf.py
@@ -1,0 +1,3 @@
+# pylint: skip-file
+project = "Odoo Hooks Documentation"
+root_doc = "index"

--- a/docs/index.rst
+++ b/docs/index.rst
@@ -1,0 +1,9 @@
+Odoo pre-commit hooks
+#####################
+The documentation provides in-depth information about several topics, with the section on messages perhaps being
+the most useful to users. It explains the rational behind more nuanced, not so obvious messages and provides tips
+on how to fix your code.
+
+.. toctree::
+
+  messages/index

--- a/docs/messages/index.rst
+++ b/docs/messages/index.rst
@@ -1,0 +1,8 @@
+Messages
+########
+Most hooks provide messages with all the data required to fix the offending code. Messages which grant
+a deeper explanation are found here.
+
+.. toctree::
+
+  xml/index.rst

--- a/docs/messages/xml/index.rst
+++ b/docs/messages/xml/index.rst
@@ -1,0 +1,7 @@
+XML Messages
+############
+
+.. toctree::
+  :glob:
+
+  *

--- a/docs/messages/xml/oe-structure-missing-id.rst
+++ b/docs/messages/xml/oe-structure-missing-id.rst
@@ -1,0 +1,39 @@
+xml-oe-structure-missing-id
+###########################
+This message is generated whenever a tag having :code:`oe_structure` as one of its classes is missing a valid
+:code:`id`. A valid :code:`id` must contain :code:`oe_structure` inside it. So :code:`id="my_unique_id"` is not valid,
+while :code:`id="oe_structure_my_unique_id"` is valid.
+
+Rationale
+*********
+The check was suggested in `this issue <https://github.com/OCA/odoo-pre-commit-hooks/issues/27>`_. Tags with
+:code:`oe_structure` as their class are meant for users to edit them through the website builder. If the tag has no
+:code:`id`, the website will replace the entire original view with a copy that contains the user changes.
+This means updates to other parts of the view (through code, AKA updating a module) may not be reflected.
+
+By providing a valid :code:`id`, only the tag with it will be replaced. Internally Odoo will inherit the original view
+and use an XPath to replace the tag with the user's content. This means the rest of the view can still be updated
+and changes should be reflected.
+
+Fixing your code
+****************
+To fix your code you should first of all determine whether the content inside the offending tag should be
+editable by users. If it shouldn't, removing :code:`oe_structure` is probably the best solution.
+
+If the content is meant to be edited by users then provide a valid, **unique** ID. In order to avoid collisions
+it is often recommended for the ID to contain the template's ID in it. For example:
+
+.. code-block:: xml
+
+  <template id="customer_template_blue" name="Blue Customer Template">
+    <main>
+      Some stuff that should not be edited
+    </main>
+    <div class="oe_structure" id="oe_structure_customer_template_blue_greeting">
+      <span>Customize this greeting through the website editor!</span>
+    </div>
+  </template>
+
+Additionally **ensure your code does not depend on any elements inside tags with oe_structure**. User editable
+content is volatile and subject to changes or complete removal (if the user so wishes), so something like an
+XPath expression may break if the user removes elements referenced in it.

--- a/src/oca_pre_commit_hooks/checks_odoo_module_xml.py
+++ b/src/oca_pre_commit_hooks/checks_odoo_module_xml.py
@@ -23,7 +23,9 @@ etree.FunctionNamespace(None)["hasclass"] = _hasclass
 
 class ChecksOdooModuleXML(BaseChecker):
     xpath_deprecated_data = etree.XPath("/odoo[count(./*) < 2]/data|/openerp[count(./*) < 2]/data")
-    xpath_oe_structure_woid = etree.XPath("//*[hasclass('oe_structure') and not(@id)]")
+    xpath_oe_structure_woid = etree.XPath(
+        "//*[hasclass('oe_structure') and (not(@id) or not(contains(@id, 'oe_structure')))]"
+    )
     xpath_record_wid = etree.XPath("/odoo//record[@id] | /openerp//record[@id]")
     xpath_view_arch_xml = etree.XPath("field[@name='arch' and @type='xml'][1]")
     xpath_ir_fields = etree.XPath("field[@name='name' or @name='user_id']")
@@ -378,5 +380,6 @@ class ChecksOdooModuleXML(BaseChecker):
             for xpath_node in self.xpath_oe_structure_woid(manifest_data["node"]):
                 self.checks_errors["xml-oe-structure-missing-id"].append(
                     f'{manifest_data["filename_short"]}:{xpath_node.sourceline} '
-                    f"Consider removing the class 'oe_structure' or adding an id to the tag"
+                    "Consider removing the class 'oe_structure' or adding a proper id to the tag. The id must contain "
+                    "'oe_structure'"
                 )

--- a/test_repo/test_module/website_templates.xml
+++ b/test_repo/test_module/website_templates.xml
@@ -7,11 +7,10 @@
             <span t-esc="price" t-esc-options='{"widget": "monetary"}'/>
         </div>
         <section class="oe_structure">
-            <p>Customize this!</p>
+            <p>Customize this! It is missing an ID</p>
         </section>
-        <div class="oe_structure_gotcha">
-            <span>I did nothing wrong :)</span>
-        </div>
+        <div class="oe_structure_gotcha"/>
+        <main class="oe_structure oe_hello"/>
         <div class="d-flex fake_oe_structure"/>
     </template>
 
@@ -20,10 +19,16 @@
         <div>
             <span t-field="line.image" t-field-options='{"widget": "image"}'/>
         </div>
-        <div id="correct_oe_structure" class="oe_structure"/>
+        <div id="id_oe_structure" class="oe_structure"/>
         <body>
             <div class="oe_structure px-1 py-2">
-                <span>Hello</span>
+                <span>Hello. Please add an ID on this!!</span>
+            </div>
+            <div class="oe_structure"/>
+            <div id="oe_structure_div_2" class="oe_structure"/>
+            <div id="unique_id_oe_structure" class="oe_structure"/>
+            <div id="_id_with_children" class="oe_structure">
+                <span>Invalid ID :(</span>
             </div>
         </body>
     </template>

--- a/test_repo/test_module/website_templates_disable.xml
+++ b/test_repo/test_module/website_templates_disable.xml
@@ -12,9 +12,13 @@
 
     <!-- Deprecated QWeb directive "t-field-options". -->
     <template id="test_template_2" name="Test Template 2">
+        <div class="oe_structure" id="oe_structure_test_template_2_1">
+            <span>This shows proper usage. Default content is provided but can be modified/replaced by the user!</span>
+        </div>
         <div>
             <span t-field="line.image" t-field-options='{"widget": "image"}'/>
         </div>
+        <footer class="oe_structure"/>
     </template>
 
     <template id="assets_backend" name="test_module_widget" inherit_id="web.assets_backend">

--- a/tests/test_checks.py
+++ b/tests/test_checks.py
@@ -35,7 +35,7 @@ EXPECTED_ERRORS = {
     "xml-syntax-error": 2,
     "xml-view-dangerous-replace-low-priority": 6,
     "xml-xpath-translatable-item": 4,
-    "xml-oe-structure-missing-id": 2,
+    "xml-oe-structure-missing-id": 6,
 }
 
 


### PR DESCRIPTION
Related to https://github.com/OCA/odoo-pre-commit-hooks/issues/27.

The lint will now trigger on elements with an invalid id. For odoo
to consider it, the id must contain oe_structure. (See link below).

https://github.com/odoo/odoo/blob/25edcc89273c389f318c434ce9a9e0b531b8e599/addons/web_editor/models/ir_ui_view.py#L41

Aditionally documentation for in-depth explanation on this hook has been
added.