### PR TITLE
[REF] Don't filter out messages, move is_message_enabled

### DIFF
--- a/src/oca_pre_commit_hooks/base_checker.py
+++ b/src/oca_pre_commit_hooks/base_checker.py
@@ -1,5 +1,5 @@
 from collections import defaultdict
-from typing import Set
+from typing import Set, Union
 
 
 class BaseChecker:
@@ -11,3 +11,13 @@ class BaseChecker:
 
         self.checks_errors = defaultdict(list)
         self.needs_autofix = False
+
+    def is_message_enabled(self, message: str, extra_disable: Union[Set, None] = None):
+        if extra_disable:
+            return message not in extra_disable
+        if self.enable:
+            return message in self.enable
+        if self.disable:
+            return message not in self.disable
+
+        return True

--- a/src/oca_pre_commit_hooks/checks_odoo_module.py
+++ b/src/oca_pre_commit_hooks/checks_odoo_module.py
@@ -129,7 +129,7 @@ class ChecksOdooModule(BaseChecker):
         checks_obj = checks_odoo_module_xml.ChecksOdooModuleXML(
             manifest_datas, self.odoo_addon_name, self.enable, self.disable
         )
-        for check_meth in utils.getattr_checks(checks_obj, self.enable, self.disable):
+        for check_meth in utils.getattr_checks(checks_obj):
             check_meth()
         self.checks_errors.update(checks_obj.checks_errors)
 
@@ -141,7 +141,7 @@ class ChecksOdooModule(BaseChecker):
         checks_obj = checks_odoo_module_csv.ChecksOdooModuleCSV(
             manifest_datas, self.odoo_addon_name, self.enable, self.disable
         )
-        for check_meth in utils.getattr_checks(checks_obj, self.enable, self.disable):
+        for check_meth in utils.getattr_checks(checks_obj):
             check_meth()
         self.checks_errors.update(checks_obj.checks_errors)
 
@@ -196,9 +196,8 @@ def run(files_or_modules, enable=None, disable=None, no_verbose=False, no_exit=F
         checks_obj = ChecksOdooModule(
             os.path.realpath(manifest_path), enable, disable, changed=changed, verbose=not no_verbose, autofix=autofix
         )
-        for check in utils.getattr_checks(checks_obj, enable=enable, disable=disable):
+        for check in utils.getattr_checks(checks_obj):
             check()
-        utils.filter_checks_enabled_disabled(checks_obj.checks_errors, enable, disable)
         if checks_obj.checks_errors:
             all_check_errors.append(checks_obj.checks_errors)
             exit_status = 1

--- a/src/oca_pre_commit_hooks/checks_odoo_module_csv.py
+++ b/src/oca_pre_commit_hooks/checks_odoo_module_csv.py
@@ -1,16 +1,23 @@
 import csv
 import os
 from collections import defaultdict
+from typing import Sequence, Set, Union
 
 from oca_pre_commit_hooks import utils
 from oca_pre_commit_hooks.base_checker import BaseChecker
 
 
 class ChecksOdooModuleCSV(BaseChecker):
-    def __init__(self, manifest_datas, module_name, enable, disable):
+    def __init__(
+        self,
+        manifest_datas: Union[Sequence, None] = None,
+        module_name: str = None,
+        enable: Union[Set, None] = None,
+        disable: Union[Set, None] = None,
+    ):
         super().__init__(enable, disable, module_name)
 
-        self.manifest_datas = manifest_datas
+        self.manifest_datas = manifest_datas or []
         for manifest_data in manifest_datas:
             manifest_data.update(
                 {
@@ -44,12 +51,15 @@ class ChecksOdooModuleCSV(BaseChecker):
                             )
                         )
             except (FileNotFoundError, csv.Error, UnicodeDecodeError) as csv_err:
-                self.checks_errors["csv-syntax-error"].append(f'{manifest_data["filename_short"]}:1 {csv_err}')
-        for csvid, records in csvids.items():
-            if len(records) < 2:
-                continue
-            self.checks_errors["csv-duplicate-record-id"].append(
-                f"{records[0][0]}:{records[0][1]} "
-                f'Duplicate CSV record id "{csvid}" in '
-                f'{", ".join(f"{record[0]}:{record[1]}" for record in records[1:])}'
-            )
+                if self.is_message_enabled("csv-syntax-error"):
+                    self.checks_errors["csv-syntax-error"].append(f'{manifest_data["filename_short"]}:1 {csv_err}')
+
+        if self.is_message_enabled("csv-duplicate-record-id"):
+            for csvid, records in csvids.items():
+                if len(records) < 2:
+                    continue
+                self.checks_errors["csv-duplicate-record-id"].append(
+                    f"{records[0][0]}:{records[0][1]} "
+                    f'Duplicate CSV record id "{csvid}" in '
+                    f'{", ".join(f"{record[0]}:{record[1]}" for record in records[1:])}'
+                )

--- a/src/oca_pre_commit_hooks/checks_odoo_module_xml.py
+++ b/src/oca_pre_commit_hooks/checks_odoo_module_xml.py
@@ -54,7 +54,7 @@ class ChecksOdooModuleXML(BaseChecker):
 
     def __init__(self, manifest_datas, module_name, enable, disable):
         super().__init__(enable, disable, module_name)
-        self.manifest_datas = manifest_datas
+        self.manifest_datas = manifest_datas or []
         for manifest_data in self.manifest_datas:
             try:
                 with open(manifest_data["filename"], "rb") as f_xml:
@@ -90,11 +90,7 @@ class ChecksOdooModuleXML(BaseChecker):
 
     def getattr_checks(self, manifest_data, prefix):
         disable_node = manifest_data["disabled_checks"]
-        yield from utils.getattr_checks(self, self.enable, self.disable, prefix, disable_node)
-
-    def is_message_enabled(self, checks, manifest_data):
-        disable_node = manifest_data["disabled_checks"]
-        return utils.is_message_enabled(checks, self.enable, self.disable, disable_node)
+        yield from utils.getattr_checks(self, prefix, disable_node)
 
     @classmethod
     def _get_priority(cls, view):
@@ -136,7 +132,7 @@ class ChecksOdooModuleXML(BaseChecker):
             for record in self.xpath_record_wid(manifest_data["node"]):
                 record_id = record.get("id")
 
-                if self.is_message_enabled("xml-duplicate-record-id", manifest_data):
+                if self.is_message_enabled("xml-duplicate-record-id", manifest_data["disabled_checks"]):
                     # xmlids_duplicated
                     xmlid_key = (
                         f"{manifest_data['data_section']}/{record_id}"
@@ -145,7 +141,7 @@ class ChecksOdooModuleXML(BaseChecker):
                     xmlids_section[xmlid_key].append((manifest_data, record))
 
                 # fields_duplicated
-                if self.is_message_enabled("xml-duplicate-fields", manifest_data):
+                if self.is_message_enabled("xml-duplicate-fields", manifest_data["disabled_checks"]):
                     for field in self.xpath_record_fields_wname(record):
                         xml_fields[(field.get("name"), field.getparent())].append((manifest_data, field))
 
@@ -219,24 +215,26 @@ class ChecksOdooModuleXML(BaseChecker):
         if record.get("model") != "ir.ui.view":
             return
         # view_dangerous_replace_low_priority
-        priority = self._get_priority(record)
-        is_replaced_field = self._is_replaced_field(record)
-        # TODO: Add self.config.min_priority instead of DFTL_MIN_PRIORITY
-        if is_replaced_field and priority < DFTL_MIN_PRIORITY:
-            self.checks_errors["xml-view-dangerous-replace-low-priority"].append(
-                f'{manifest_data["filename_short"]}:{record.sourceline} '
-                'Dangerous use of "replace" from view '
-                f"with priority {priority} < {DFTL_MIN_PRIORITY}. "
-                'Only replace as a last resort. Try position="attributes", position="move" or invisible="1" first'
-            )
+        if self.is_message_enabled("xml-view-dangerous-replace-low-priority", manifest_data["disabled_checks"]):
+            priority = self._get_priority(record)
+            is_replaced_field = self._is_replaced_field(record)
+            # TODO: Add self.config.min_priority instead of DFTL_MIN_PRIORITY
+            if is_replaced_field and priority < DFTL_MIN_PRIORITY:
+                self.checks_errors["xml-view-dangerous-replace-low-priority"].append(
+                    f'{manifest_data["filename_short"]}:{record.sourceline} '
+                    'Dangerous use of "replace" from view '
+                    f"with priority {priority} < {DFTL_MIN_PRIORITY}. "
+                    'Only replace as a last resort. Try position="attributes", position="move" or invisible="1" first'
+                )
 
         # deprecated_tree_attribute
-        for deprecate_attr_node in self.xpath_tree_deprecated(record):
-            deprecate_attr_str = ",".join(set(deprecate_attr_node.attrib.keys()) & self.tree_deprecate_attrs)
-            self.checks_errors["xml-deprecated-tree-attribute"].append(
-                f'{manifest_data["filename_short"]}:{deprecate_attr_node.sourceline} '
-                f'Deprecated "<tree {deprecate_attr_str}=..."'
-            )
+        if self.is_message_enabled("xml-deprecated-tree-attribute", manifest_data["disabled_checks"]):
+            for deprecate_attr_node in self.xpath_tree_deprecated(record):
+                deprecate_attr_str = ",".join(set(deprecate_attr_node.attrib.keys()) & self.tree_deprecate_attrs)
+                self.checks_errors["xml-deprecated-tree-attribute"].append(
+                    f'{manifest_data["filename_short"]}:{deprecate_attr_node.sourceline} '
+                    f'Deprecated "<tree {deprecate_attr_str}=..."'
+                )
 
     @utils.only_required_for_checks("xml-create-user-wo-reset-password")
     def visit_xml_record_user(self, manifest_data, record):
@@ -277,7 +275,7 @@ class ChecksOdooModuleXML(BaseChecker):
         """* Check xml-not-valid-char-link
         The resource in in src/href contains a not valid character."""
         for manifest_data in self.manifest_datas:
-            if not self.is_message_enabled("xml-not-valid-char-link", manifest_data):
+            if not self.is_message_enabled("xml-not-valid-char-link", manifest_data["disabled_checks"]):
                 continue
 
             for node in self.xpath_char_links(manifest_data["node"]):
@@ -294,7 +292,9 @@ class ChecksOdooModuleXML(BaseChecker):
         """* Check xml-dangerous-qweb-replace-low-priority
         Dangerous qweb view defined with low priority"""
         for manifest_data in self.manifest_datas:
-            if not self.is_message_enabled("xml-dangerous-qweb-replace-low-priority", manifest_data):
+            if not self.is_message_enabled(
+                "xml-dangerous-qweb-replace-low-priority", manifest_data["disabled_checks"]
+            ):
                 continue
             for template in self.xpath_template(manifest_data["node"]):
                 try:
@@ -317,7 +317,7 @@ class ChecksOdooModuleXML(BaseChecker):
         """* Check xml-deprecated-data-node
         Deprecated <data> node inside <odoo> xml node"""
         for manifest_data in self.manifest_datas:
-            if not self.is_message_enabled("xml-deprecated-data-node", manifest_data):
+            if not self.is_message_enabled("xml-deprecated-data-node", manifest_data["disabled_checks"]):
                 continue
             for data_node in self.xpath_deprecated_data(manifest_data["node"]):
                 # TODO: Add autofix option
@@ -332,7 +332,7 @@ class ChecksOdooModuleXML(BaseChecker):
         """* Check xml-deprecated-openerp-node
         deprecated <openerp> xml node"""
         for manifest_data in self.manifest_datas:
-            if not self.is_message_enabled("xml-deprecated-openerp-node", manifest_data):
+            if not self.is_message_enabled("xml-deprecated-openerp-node", manifest_data["disabled_checks"]):
                 continue
             for openerp_node in self.xpath_openerp(manifest_data["node"]):
                 # TODO: Add autofix option
@@ -345,7 +345,7 @@ class ChecksOdooModuleXML(BaseChecker):
         """* Check xml-deprecated-qweb-directive
         for use of deprecated QWeb directives t-*-options"""
         for manifest_data in self.manifest_datas:
-            if not self.is_message_enabled("xml-deprecated-qweb-directive", manifest_data):
+            if not self.is_message_enabled("xml-deprecated-qweb-directive", manifest_data["disabled_checks"]):
                 continue
             for node in self.xpath_qweb_deprecated(manifest_data["node"]):
                 directive_str = ", ".join(set(node.attrib) & self.qweb_deprecated_directives)


### PR DESCRIPTION
Related to #77.

* Messages are no longer filtered out. Instead they are not generated in the first place. This prevents subtle bugs from being introduced, where a check is run (unwanted) and no one notices it because its messages are filtered out. It also simplifies the program's flow and avoids useless execution.

* is_message_enabled has been moved to BaseChecker, this makes code easier and removes redundancy since the same enable, disable sets were being passed around constantly.