### PR TITLE
[IMP] add xml-record-missing-id

### DIFF
--- a/README.md
+++ b/README.md
@@ -161,6 +161,9 @@ be disabled.
 * Check xml-deprecated-tree-attribute
           The tree-view declaration is using a deprecated attribute.
 
+* Check xml-record-missing-id
+        Generated when a <record> tag has no id.
+
 * Check xml-duplicate-record-id
 
         If a module has duplicated record_id AKA xml_ids
@@ -363,6 +366,11 @@ options:
     - https://github.com/OCA/odoo-pre-commit-hooks/blob/v0.0.28/test_repo/test_module/website_templates.xml#L30 Consider removing the class 'oe_structure' or adding a proper id to the tag. The id must contain 'oe_structure'
     - https://github.com/OCA/odoo-pre-commit-hooks/blob/v0.0.28/test_repo/test_module/website_templates.xml#L9 Consider removing the class 'oe_structure' or adding a proper id to the tag. The id must contain 'oe_structure'
     - https://github.com/OCA/odoo-pre-commit-hooks/blob/v0.0.28/test_repo/test_module/website_templates_disable.xml#L21 Consider removing the class 'oe_structure' or adding a proper id to the tag. The id must contain 'oe_structure'
+
+ * xml-record-missing-id
+
+    - https://github.com/OCA/odoo-pre-commit-hooks/blob/v0.0.28/test_repo/broken_module/model_view.xml#L21 Record has no id, add a unique one to create a new record, use an existing one to update it
+    - https://github.com/OCA/odoo-pre-commit-hooks/blob/v0.0.28/test_repo/broken_module/model_view.xml#L24 Record has no id, add a unique one to create a new record, use an existing one to update it
 
  * xml-redundant-module-name
 

--- a/test_repo/broken_module/model_view.xml
+++ b/test_repo/broken_module/model_view.xml
@@ -20,5 +20,7 @@
         <!-- Record without "id" -->
         <record model="ir.ui.view"/>
 
+        <!-- Also no "id" -->
+        <record id="" model="ir.ui.view"/>
     </data>
 </openerp>

--- a/tests/test_checks.py
+++ b/tests/test_checks.py
@@ -36,6 +36,7 @@ EXPECTED_ERRORS = {
     "xml-view-dangerous-replace-low-priority": 6,
     "xml-xpath-translatable-item": 4,
     "xml-oe-structure-missing-id": 6,
+    "xml-record-missing-id": 2,
 }
 
 


### PR DESCRIPTION
Closes #63.

This adds a new check for records that don't have an xmlid. It reuses the existing loop that goes over all records in the XML file to find records without an id.