### PR TITLE
[REF] setup: Enable py311 classifier (#117)

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -21,14 +21,16 @@ jobs:
         include:
           - python: '3.10'
             os: ubuntu-latest
-            tox_env: 'py,lint,update-readme,build'
+            tox_env: 'lint'
+          - python: '3.10'
+            os: ubuntu-latest
+            tox_env: 'update-readme'
+          - python: '3.10'
+            os: ubuntu-latest
+            tox_env: 'build'
           - python: '3.10'
             os: ubuntu-latest
             tox_env: 'cprofile'
-        exclude:
-          - python: '3.11'
-            os: windows-latest
-
 
     steps:
     - name: Set git to not change EoL

--- a/setup.py
+++ b/setup.py
@@ -75,6 +75,7 @@ setup(
         "Programming Language :: Python :: 3.8",
         "Programming Language :: Python :: 3.9",
         "Programming Language :: Python :: 3.10",
+        "Programming Language :: Python :: 3.11",
         "Topic :: Utilities",
     ],
     project_urls={


### PR DESCRIPTION
 - Re-enable py3.11 windows build
 - Remove duplicated included build py-3.10
 - Split builds for lint, docs and build in order to improve detection of errors