### PR TITLE
CI improvements

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -43,7 +43,7 @@ jobs:
       with:
         path: ~/.cache/pre-commit
         key: ${{ runner.os }}-py${{ matrix.python }}-pre-commit
-    - uses: actions/checkout@v2
+    - uses: actions/checkout@v4
       with:
         fetch-depth: 0
     - uses: actions/setup-python@v4

--- a/setup.py
+++ b/setup.py
@@ -22,8 +22,7 @@ def generate_changelog():
     # pylint: disable=protected-access
     changelog = git._iter_log_oneline()
     changelog = git._iter_changelog(changelog)
-    git.write_git_changelog(changelog=changelog)
-    # git.generate_authors()
+    git.write_git_changelog(changelog=filter(lambda log: not log[1].startswith("* Bump version"), changelog))
     return read(fname)
 
 

--- a/tox.ini
+++ b/tox.ini
@@ -49,10 +49,7 @@ commands =
 [testenv:build]
 skip_install = true
 deps =
-    build
-    bump2version
-    twine
-    wheel
+    {[testenv]deps}
 commands =
     python -m build --sdist --wheel --outdir dist_wo_pbr/
     python -c "import shutil;shutil.rmtree('dist/', ignore_errors=True)"


### PR DESCRIPTION
1. Changelog is now being generated. This can be verified by running `tox -e build` and untarring the resulting files in `dist/`
2. actions/checkout@v2 was deprecated and emitting warnings, therefore it has been updated.