### PR TITLE
[IMP] adds a new checked for filenames

### DIFF
--- a/README.md
+++ b/README.md
@@ -224,6 +224,15 @@ be disabled.
 
 [//]: # (end-checks-po)
 
+[//]: # (start-checks-file)
+
+# Checks file
+
+* Check space-in-filename
+        Verify that all files do not contain spaces in their name
+
+[//]: # (end-checks-file)
+
 
 [//]: # (start-help)
 

--- a/setup.py
+++ b/setup.py
@@ -94,6 +94,7 @@ setup(
         "console_scripts": [
             "oca-checks-odoo-module = oca_pre_commit_hooks.cli:main",
             "oca-checks-po = oca_pre_commit_hooks.cli_po:main",
+            "oca-checks-file = oca_pre_commit_hooks.cli_file:main",
         ]
     },
 )

--- a/src/oca_pre_commit_hooks/checks_odoo_files.py
+++ b/src/oca_pre_commit_hooks/checks_odoo_files.py
@@ -1,0 +1,110 @@
+#!/usr/bin/env python3
+import os
+import sys
+
+from oca_pre_commit_hooks import checks_odoo_module_csv, checks_odoo_module_xml, utils
+from oca_pre_commit_hooks.base_checker import BaseChecker
+
+DFTL_README_TMPL_URL = "https://github.com/OCA/maintainer-tools/blob/master/template/module/README.rst"  # noqa: B950
+DFTL_README_FILES = ["README.md", "README.txt", "README.rst"]
+DFTL_MANIFEST_DATA_KEYS = ["data", "demo", "demo_xml", "init_xml", "qweb", "test", "update_xml"]
+MANIFEST_NAMES = ("__openerp__.py", "__manifest__.py")
+
+
+class ChecksOdooFiles(BaseChecker):
+    def __init__(self, path, enable, disable, verbose=False, autofix=False, autofix_char=None):
+        super().__init__(enable, disable, autofix=autofix)
+        self.path = path
+        self.verbose = verbose
+        if self.autofix:
+            if autofix_char is None:
+                self.autofix_char = "_"
+            elif autofix_char in "/\\.: ":
+                self.print(f"Illegal autofix_char {autofix_char} changed to _")
+                self.autofix_char = "_"
+            else:
+                self.autofix_char = autofix_char
+
+    def _prepend_path(self, path, files):
+        return [(path, f) for f in files]
+
+    def _perform_autofix(self, path, file):
+        new_name = file.replace(" ", self.autofix_char)
+        tentative_name = new_name
+        i = 1
+        while os.path.isfile(os.path.join(path, tentative_name)):
+            root, ext = os.path.splitext(new_name)
+            tentative_name = f"{root}_{i}{ext}"
+            i += 1
+        self.print('File ' + os.path.join(path, file) + ' renamed to ' + os.path.join(path, tentative_name))
+        os.rename(os.path.join(path, file), os.path.join(path, tentative_name))
+
+    def check_filename_spaces(self):
+        """Checks sape-in-filename
+        Checks if the filename has spaces
+        """
+        if os.path.isdir(self.path):
+            
+            file_list = sum(
+                [self._prepend_path(path, files) for path, _, files in os.walk(self.path)],
+                []
+            )
+
+            for path, file in file_list:
+                if ' ' in file:
+                    self.checks_errors["space-in-filename"].append(
+                        f"file {file} has a space in its name"
+                    )
+                    if self.autofix:
+                        self._perform_autofix(path, file)
+        else:
+            self.print(f"Directory {self.path} does not exist")
+
+    def print(self, object2print):
+        if not self.verbose:
+            return
+        print(object2print)
+
+
+def run(paths, enable=None, disable=None, no_verbose=False, no_exit=False, list_msgs=False, autofix=False, autofix_char=None):
+    if list_msgs:
+        _, checks_docstring = utils.get_checks_docstring(
+            [ChecksOdooFiles, checks_odoo_module_csv.ChecksOdooModuleCSV, checks_odoo_module_xml.ChecksOdooModuleXML]
+        )
+        if not no_verbose:
+            print("Emittable messages with the current interpreter:", end="")
+            print(checks_docstring)
+        if no_exit:
+            return checks_docstring
+        sys.exit(0)
+
+    all_check_errors = []
+    if enable is None:
+        enable = set()
+    if disable is None:
+        disable = set()
+    exit_status = 0
+    for path in paths:
+        checks_obj = ChecksOdooFiles(
+            path, enable, disable, verbose=not no_verbose, autofix=autofix, autofix_char=autofix_char
+        )
+        for check in utils.getattr_checks(checks_obj):
+            check()
+        if checks_obj.checks_errors:
+            all_check_errors.append(checks_obj.checks_errors)
+            exit_status = 1
+        for check_error, msgs in checks_obj.checks_errors.items() if not no_verbose else {}:
+            checks_obj.print(f"\n****{check_error}****")
+            for msg in msgs:
+                checks_obj.print(f"{msg} - [{check_error}]")
+    if no_exit:
+        return all_check_errors
+    sys.exit(exit_status)
+
+
+def main(**kwargs):
+    return run(**kwargs)
+
+
+if __name__ == "__main__":
+    main()

--- a/src/oca_pre_commit_hooks/cli_file.py
+++ b/src/oca_pre_commit_hooks/cli_file.py
@@ -1,0 +1,39 @@
+#!/usr/bin/env python3
+"""Module that contains the command line app.
+Why does this file exist, and why not put this in __main__?
+  You might be tempted to import things from __main__ later, but that will cause
+  problems: the code will get executed twice:
+  - When you run `python -mpre_commit_vauxoo` python will execute
+    ``__main__.py`` as a script. That means there won't be any
+    ``pre_commit_vauxoo.__main__`` in ``sys.modules``.
+  - When you import __main__ it will get executed again (as a module) because
+    there's no ``pre_commit_vauxoo.__main__`` in ``sys.modules``.
+  Also see (1) from http://click.pocoo.org/5/setuptools/#setuptools-integration
+"""
+
+import sys
+
+from oca_pre_commit_hooks import checks_odoo_files
+from oca_pre_commit_hooks.global_parser import GlobalParser
+
+
+def main(argv=None):
+    parser = GlobalParser()
+    parser.add_argument(
+        "paths",
+        nargs="*",
+        help="Paths which contain data files.",
+    )
+    parser.add_argument(
+        "--autofix-char",
+        help="Character to use to fill spaces in file names (default: _)",
+        metavar="CHAR"
+    )
+    if argv is None:
+        argv = sys.argv[1:]
+    kwargs = vars(parser.parse_args(argv))
+    return checks_odoo_files.main(**kwargs)
+
+
+if __name__ == "__main__":
+    main()


### PR DESCRIPTION
It could be desirable to have a checker that only lints filenames themselves and not their contents.

In this commit we add one which is only verifying that the name does not contain spaces, with its obvious implications for OS compatibilities.