### PR TITLE
[REF] github-actions: Use macosx-latest only for py-latest and macosx-14 for older

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -21,7 +21,7 @@ jobs:
       fail-fast: false
       matrix:
         python: ['3.7', '3.8', '3.9', '3.10', '3.11', '3.12']
-        os: [ubuntu-latest, windows-latest, macos-latest]
+        os: [ubuntu-latest, windows-latest, macos-13]
         tox_env: ["py"]
         include:
           - python: '3.12'
@@ -36,6 +36,11 @@ jobs:
           - python: '3.12'
             os: ubuntu-latest
             tox_env: 'cprofile'
+          # macos-14 AKA macos-latest has switched to being an ARM runner, only supporting newer versions of Python
+          # https://github.com/actions/setup-python/issues/825#issuecomment-2096792396
+          - python: '3.12'
+            os: macos-latest
+            tox_env: 'py'
 
     steps:
     - name: Set git to not change EoL

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,2 +1,6 @@
 [tool.black]
 line-length=119
+
+[build-system]
+requires = ["setuptools >=42"]
+build-backend = "setuptools.build_meta"

--- a/test-requirements.txt
+++ b/test-requirements.txt
@@ -9,3 +9,4 @@ pytest-xdist
 tox
 twine
 wheel
+setuptools >=42


### PR DESCRIPTION
Related to https://github.com/actions/setup-python/issues/825\#issuecomment-2096792396