### PR TITLE
[FIX] unwanted execution of globally disabled checks

### DIFF
--- a/README.md
+++ b/README.md
@@ -399,6 +399,7 @@ options:
     - https://github.com/OCA/odoo-pre-commit-hooks/blob/v0.0.31/test_repo/broken_module/model_view2.xml#L47 Dangerous use of "replace" from view with priority 0 < 99. Only replace as a last resort. Try position="attributes", position="move" or invisible="1" first
     - https://github.com/OCA/odoo-pre-commit-hooks/blob/v0.0.31/test_repo/broken_module/model_view2.xml#L70 Dangerous use of "replace" from view with priority 10 < 99. Only replace as a last resort. Try position="attributes", position="move" or invisible="1" first
     - https://github.com/OCA/odoo-pre-commit-hooks/blob/v0.0.31/test_repo/broken_module/model_view2.xml#L92 Dangerous use of "replace" from view with priority 10 < 99. Only replace as a last resort. Try position="attributes", position="move" or invisible="1" first
+    - https://github.com/OCA/odoo-pre-commit-hooks/blob/v0.0.31/test_repo/broken_module/skip_xml_check_3.xml#L15 Dangerous use of "replace" from view with priority 0 < 99. Only replace as a last resort. Try position="attributes", position="move" or invisible="1" first
 
  * xml-xpath-translatable-item
 

--- a/src/oca_pre_commit_hooks/base_checker.py
+++ b/src/oca_pre_commit_hooks/base_checker.py
@@ -13,8 +13,8 @@ class BaseChecker:
         self.needs_autofix = False
 
     def is_message_enabled(self, message: str, extra_disable: Union[Set, None] = None):
-        if extra_disable:
-            return message not in extra_disable
+        if extra_disable and message in extra_disable:
+            return False
         if self.enable:
             return message in self.enable
         if self.disable:

--- a/test_repo/broken_module/skip_xml_check_3.xml
+++ b/test_repo/broken_module/skip_xml_check_3.xml
@@ -11,5 +11,14 @@
             <field name="name">view.model.form80</field>
             <field name="model">test.model</field>
         </record>
+        <!-- the check xml-dangerous-view-replace-low-priority is not disabled, so it must fail -->
+        <record id="view_model_skip_but_checked" model="ir.ui.view">
+            <field name="name">view.model.form80</field>
+            <field name="model">test.model</field>
+            <field name="inherit_id" ref="module.template"/>
+            <field name="arch" type="xml">
+                <field name="address" position="replace"/>
+            </field>
+        </record>
     </data>
 </odoo>

--- a/tests/test_checks.py
+++ b/tests/test_checks.py
@@ -33,7 +33,7 @@ EXPECTED_ERRORS = {
     "xml-not-valid-char-link": 2,
     "xml-redundant-module-name": 1,
     "xml-syntax-error": 2,
-    "xml-view-dangerous-replace-low-priority": 6,
+    "xml-view-dangerous-replace-low-priority": 7,
     "xml-xpath-translatable-item": 4,
     "xml-oe-structure-missing-id": 6,
     "xml-record-missing-id": 2,


### PR DESCRIPTION
If some checks were disabled inline on a file, the global disabled checks were ignored and possibly executed.

This is likely a regression since d7753c87, where the `is_message_enabled` was refactorized and this condition was changed.