### PR TITLE
[IMP] check_odoo_module_po: extract line number from error message

### DIFF
--- a/README.md
+++ b/README.md
@@ -459,8 +459,8 @@ options:
 
  * po-syntax-error
 
-    - https://github.com/OCA/odoo-pre-commit-hooks/blob/v0.0.32/test_repo/broken_module2/i18n/en.po#L1 Syntax error in po file (line 1)
-    - https://github.com/OCA/odoo-pre-commit-hooks/blob/v0.0.32/test_repo/syntax_err_module/i18n/es.po#L1 Syntax error in po file (line 19)
+    - https://github.com/OCA/odoo-pre-commit-hooks/blob/v0.0.32/test_repo/broken_module2/i18n/en.po#L1 Syntax error in po file
+    - https://github.com/OCA/odoo-pre-commit-hooks/blob/v0.0.32/test_repo/syntax_err_module/i18n/es.po#L19 Syntax error in po file
 
 [//]: # (end-example-po)
 

--- a/src/oca_pre_commit_hooks/checks_odoo_module_po.py
+++ b/src/oca_pre_commit_hooks/checks_odoo_module_po.py
@@ -109,11 +109,12 @@ class ChecksOdooModulePO(BaseChecker):
     @staticmethod
     def extract_line_no(error_msg):
         """Removes (line n) from the message error and returns n with the new message"""
-        line_regex = re.search(r" \(line (\d+)\)", error_msg)
-        line_no = None
+        error_regex = re.compile(r" \(line (\d+)\)")
+        line_regex = error_regex.search(error_msg)
+        line_no = 1
         if line_regex:
             line_no = int(line_regex.group(1))
-            error_msg = error_msg[: line_regex.start()] + error_msg[line_regex.end() :]
+            error_msg = error_regex.sub("", error_msg)
         return line_no, error_msg
 
     @utils.only_required_for_checks("po-syntax-error")

--- a/src/oca_pre_commit_hooks/checks_odoo_module_po.py
+++ b/src/oca_pre_commit_hooks/checks_odoo_module_po.py
@@ -114,11 +114,13 @@ class ChecksOdooModulePO(BaseChecker):
             return
         msg = str(self.file_error).replace(f"{self.filename} ", "").strip()
         line_no = 1
+
         def replace_and_extract(match):
             """Edit the original line_no variable and remove the string matched"""
             nonlocal line_no
             line_no = int(match.group(1))
             return ""
+
         msg = re.sub(r" \(line (\d+)\)", replace_and_extract, msg)
         self.register_error(
             code="po-syntax-error",

--- a/src/oca_pre_commit_hooks/checks_odoo_module_po.py
+++ b/src/oca_pre_commit_hooks/checks_odoo_module_po.py
@@ -106,17 +106,6 @@ class ChecksOdooModulePO(BaseChecker):
                 filepath=self.filename_short,
             )
 
-    @staticmethod
-    def extract_line_no(error_msg):
-        """Removes (line n) from the message error and returns n with the new message"""
-        error_regex = re.compile(r" \(line (\d+)\)")
-        line_regex = error_regex.search(error_msg)
-        line_no = 1
-        if line_regex:
-            line_no = int(line_regex.group(1))
-            error_msg = error_regex.sub("", error_msg)
-        return line_no, error_msg
-
     @utils.only_required_for_checks("po-syntax-error")
     def check_po_syntax_error(self):
         """* Check po-syntax-error
@@ -124,7 +113,13 @@ class ChecksOdooModulePO(BaseChecker):
         if not self.file_error:
             return
         msg = str(self.file_error).replace(f"{self.filename} ", "").strip()
-        line_no, msg = self.extract_line_no(msg)
+        line_no = 1
+        def replace_and_extract(match):
+            """Edit the original line_no variable and remove the string matched"""
+            nonlocal line_no
+            line_no = int(match.group(1))
+            return ""
+        msg = re.sub(r" \(line (\d+)\)", replace_and_extract, msg)
         self.register_error(
             code="po-syntax-error",
             message=msg,

--- a/src/oca_pre_commit_hooks/checks_odoo_module_po.py
+++ b/src/oca_pre_commit_hooks/checks_odoo_module_po.py
@@ -106,6 +106,16 @@ class ChecksOdooModulePO(BaseChecker):
                 filepath=self.filename_short,
             )
 
+    @staticmethod
+    def extract_line_no(error_msg):
+        """Removes (line n) from the message error and returns n with the new message"""
+        line_regex = re.search(r" \(line (\d+)\)", error_msg)
+        line_no = None
+        if line_regex:
+            line_no = int(line_regex.group(1))
+            error_msg = error_msg[: line_regex.start()] + error_msg[line_regex.end() :]
+        return line_no, error_msg
+
     @utils.only_required_for_checks("po-syntax-error")
     def check_po_syntax_error(self):
         """* Check po-syntax-error
@@ -113,11 +123,12 @@ class ChecksOdooModulePO(BaseChecker):
         if not self.file_error:
             return
         msg = str(self.file_error).replace(f"{self.filename} ", "").strip()
+        line_no, msg = self.extract_line_no(msg)
         self.register_error(
             code="po-syntax-error",
             message=msg,
             filepath=self.filename_short,
-            line=1,
+            line=line_no,
         )
 
     @staticmethod


### PR DESCRIPTION
Extract the line number from the error message, strip it away from the
string and pass it to the error printing function

Fix #107

Note: although I target the main branch, I based this on the following PR https://github.com/OCA/odoo-pre-commit-hooks/pull/106