### PR TITLE
[FIX] po-pretty-format: Allow original=translate term  for "i18n_extra" folder

### DIFF
--- a/src/oca_pre_commit_hooks/checks_odoo_module_po.py
+++ b/src/oca_pre_commit_hooks/checks_odoo_module_po.py
@@ -75,9 +75,11 @@ class ChecksOdooModulePO(BaseChecker):
 
     def _compute_pretty_contents(self):
         self.po_data.sort(key=lambda entry: entry.msgid)
-        for entry in self.po_data:
-            if entry.msgid == entry.msgstr:
-                entry.msgstr = ""
+        # Ignore i18n_extra https://github.com/OCA/odoo-pre-commit-hooks/issues/100
+        if self.data_section != "i18n_extra":
+            for entry in self.po_data:
+                if entry.msgid == entry.msgstr:
+                    entry.msgstr = ""
 
         self.pretty_contents = str(self.po_data)
 

--- a/test_repo/test_module/i18n_extra/fr.po
+++ b/test_repo/test_module/i18n_extra/fr.po
@@ -1,0 +1,19 @@
+# Translation of Odoo Server.
+msgid ""
+msgstr ""
+"Project-Id-Version: Odoo Server\n"
+"Report-Msgid-Bugs-To: \n"
+"POT-Creation-Date: 1985-04-14 17:12+0000\n"
+"PO-Revision-Date: 1985-04-14 02:03+0000\n"
+"Last-Translator: Moisés López <moylop260@vauxoo.com>\n"
+"Language-Team: \n"
+"MIME-Version: 1.0\n"
+"Content-Type: text/plain; charset=UTF-8\n"
+"Content-Transfer-Encoding: \n"
+"Plural-Forms: \n"
+
+#. module: test_module
+#: model:ir.model.fields,field_description:test_module.field_description
+#, python-format
+msgid "same msgid msgstr allowed for i18n_extra"
+msgstr "same msgid msgstr allowed for i18n_extra"


### PR DESCRIPTION
Autofix is empty the translations where the original term is the same than translated one

e.g.

msgid "CRM"
msgstr "CRM"  --> ""

However, there are valid cases to reset the translated value

But it should be only for i18n_extra folder

Fix https://github.com/OCA/odoo-pre-commit-hooks/issues/100