### PR TITLE
[REF] checks_odoo_module_po: Remove special char incompatible with windows codecs

### DIFF
--- a/src/oca_pre_commit_hooks/checks_odoo_module_po.py
+++ b/src/oca_pre_commit_hooks/checks_odoo_module_po.py
@@ -84,7 +84,7 @@ class ChecksOdooModulePO(BaseChecker):
         self.pretty_contents = str(self.po_data)
 
     def perform_autofix(self):
-        print(f"Fixing {self.filename_short} ⚒")
+        print(f"Fixing {self.filename_short}")
         with open(self.filename, "w", encoding="utf-8") as po_fd:
             po_fd.write(self.pretty_contents)
 


### PR DESCRIPTION
You can reproduce it using github actions:

```yaml
name: Reproduce UnicodeEncodeError

on:
  push:
    branches:
      - main

jobs:

  test-py-wo-fix:
    runs-on: windows-latest
    steps:
      - name: Checkout code
        uses: actions/checkout@v3

      - name: Set up Python
        uses: actions/setup-python@v4
        with:
          python-version: '3.11'

      - name: Force cp1252 encoding
        run: |
          chcp 1252
          echo "PYTHONIOENCODING=cp1252" >> $GITHUB_ENV

      - name: Run Python script
        run: |
          python -c "print('Fixing example ⚒')"
```

Note: I could not reproduce it using "tox" so it was not added to our unittest

Fix https://github.com/OCA/odoo-pre-commit-hooks/issues/95