### PR TITLE
[REF] po-duplicate-message-definition: Ignore i18n_extra folder

### DIFF
--- a/README.md
+++ b/README.md
@@ -418,9 +418,9 @@ options:
 
  * po-duplicate-message-definition
 
-    - https://github.com/OCA/odoo-pre-commit-hooks/blob/v0.1.0/test_repo/broken_module/i18n/es.po#L17 Duplicate PO message definition `Branch` in lines 23, 29
-    - https://github.com/OCA/odoo-pre-commit-hooks/blob/v0.1.0/test_repo/broken_module/i18n/es.po#L35 Duplicate PO message definition `Message id toooooooooooooooooooooooooooo...` in lines 41
-    - https://github.com/OCA/odoo-pre-commit-hooks/blob/v0.1.0/test_repo/broken_module/i18n/es.po#L65 Duplicate PO message definition `One variable {variable1}` in lines 71
+    - https://github.com/OCA/odoo-pre-commit-hooks/blob/v0.1.0/test_repo/broken_module/i18n/es.po#L17 Duplicate PO message definition `Branch` in lines 23, 29. Odoo exports these items by msgid and delete one of them. Use the `i18n_extra` folder instead of `i18n` to ignore this message.
+    - https://github.com/OCA/odoo-pre-commit-hooks/blob/v0.1.0/test_repo/broken_module/i18n/es.po#L35 Duplicate PO message definition `Message id toooooooooooooooooooooooooooo...` in lines 41. Odoo exports these items by msgid and delete one of them. Use the `i18n_extra` folder instead of `i18n` to ignore this message.
+    - https://github.com/OCA/odoo-pre-commit-hooks/blob/v0.1.0/test_repo/broken_module/i18n/es.po#L65 Duplicate PO message definition `One variable {variable1}` in lines 71. Odoo exports these items by msgid and delete one of them. Use the `i18n_extra` folder instead of `i18n` to ignore this message.
 
  * po-duplicate-model-definition
 

--- a/src/oca_pre_commit_hooks/checks_odoo_module_po.py
+++ b/src/oca_pre_commit_hooks/checks_odoo_module_po.py
@@ -330,8 +330,8 @@ class ChecksOdooModulePO(BaseChecker):
             if entry.obsolete:
                 continue
 
-            # po_duplicate_message_definition
-            if self.is_message_enabled("po-duplicate-message-definition"):
+            # Ignore i18n_extra https://github.com/OCA/odoo-pre-commit-hooks/issues/122
+            if self.is_message_enabled("po-duplicate-message-definition") and self.data_section != "i18n_extra":
                 duplicated[hash(entry.msgid)].append(entry)
 
             if self.is_message_enabled("po-duplicate-model-definition"):
@@ -351,7 +351,9 @@ class ChecksOdooModulePO(BaseChecker):
                     msg_id_short = f"{msg_id_short}..."
                 self.register_error(
                     code="po-duplicate-message-definition",
-                    message=f"Duplicate PO message definition `{msg_id_short}` in lines {duplicated_str}",
+                    message=f"Duplicate PO message definition `{msg_id_short}` in lines {duplicated_str}. "
+                    "Odoo exports these items by msgid and delete one of them. "
+                    "Use the `i18n_extra` folder instead of `i18n` to ignore this message.",
                     filepath=self.filename_short,
                     line=self._get_po_line_number(entries[0]),
                 )

--- a/test_repo/broken_module/i18n_extra/es.po
+++ b/test_repo/broken_module/i18n_extra/es.po
@@ -1,0 +1,25 @@
+#
+msgid ""
+msgstr ""
+"Project-Id-Version: Odoo Server\n"
+"Report-Msgid-Bugs-To: \n"
+"POT-Creation-Date: 1985-04-14 17:12+0000\n"
+"PO-Revision-Date: 1985-04-14 02:03+0000\n"
+"Last-Translator: Moisés López <moylop260@vauxoo.com>\n"
+"Language-Team: \n"
+"MIME-Version: 1.0\n"
+"Content-Type: text/plain; charset=UTF-8\n"
+"Content-Transfer-Encoding: \n"
+"Plural-Forms: \n"
+
+#. module: broken_module
+#: model:ir.model.fields,field_description5:broken_module.field_wizard_description5
+#, python-format
+msgid "'Duplicate PO message definition' ignored for i18n_extra"
+msgstr "'translation' 1"
+
+#. module: broken_module
+#: model:ir.model.fields,field_description10:broken_module.field_wizard_description10
+#, python-format
+msgid "'Duplicate PO message definition' ignored for i18n_extra"
+msgstr "'translation' 2"


### PR DESCRIPTION
Odoo exports translations grouped by "msgid" and it deletes duplicated

if you will not use odoo exports feature so you will need to manage manually the po file and use duplicated "msgid"

Manual PO files should be located in i18n_extra folder

This commit ignores this check for this extra folder

Fix https://github.com/OCA/odoo-pre-commit-hooks/issues/122