### PR TITLE
[IMP] deprecated_chatter check for >= v18

### DIFF
--- a/README.md
+++ b/README.md
@@ -120,6 +120,12 @@ Check syntax error for CSV files declared in the manifest
 * Check xml-deprecated-data-node
 Deprecated <data> node inside <odoo> xml node
 
+* Check xml-deprecated-oe-chatter
+
+Odoo 18 introduced a new XML tag `<chatter/>` which replaces the old way to declare
+chatters on form views. For more information, see:
+https://github.com/odoo/odoo/pull/156463
+
 * Check xml-deprecated-openerp-node
 deprecated <openerp> xml node
 
@@ -322,6 +328,10 @@ options:
     - https://github.com/OCA/odoo-pre-commit-hooks/blob/v0.1.1/test_repo/broken_module/skip_xml_check_2.xml#L3 Deprecated `<data>` node
     - https://github.com/OCA/odoo-pre-commit-hooks/blob/v0.1.1/test_repo/test_module/model_view.xml#L3 Deprecated `<data>` node
 
+ * xml-deprecated-oe-chatter
+
+    - https://github.com/OCA/odoo-pre-commit-hooks/blob/v0.1.1/test_repo/odoo18_module/views/deprecated_chatter.xml#L6 Please replace old style chatters with the new tag <chatter/>.
+
  * xml-deprecated-openerp-node
 
     - https://github.com/OCA/odoo-pre-commit-hooks/blob/v0.1.1/test_repo/broken_module/model_view.xml#L2 Deprecated `<openerp>` xml node
@@ -379,8 +389,8 @@ options:
 
  * xml-record-missing-id
 
-    - https://github.com/OCA/odoo-pre-commit-hooks/blob/v0.1.1/test_repo/broken_module/model_view.xml#L21 Record has no id, add a unique one to create a new record, use an existing one to update it
-    - https://github.com/OCA/odoo-pre-commit-hooks/blob/v0.1.1/test_repo/broken_module/model_view.xml#L24 Record has no id, add a unique one to create a new record, use an existing one to update it
+    - https://github.com/OCA/odoo-pre-commit-hooks/blob/v0.1.1/test_repo/broken_module/model_view.xml#L25 Record has no id, add a unique one to create a new record, use an existing one to update it
+    - https://github.com/OCA/odoo-pre-commit-hooks/blob/v0.1.1/test_repo/broken_module/model_view.xml#L28 Record has no id, add a unique one to create a new record, use an existing one to update it
 
  * xml-redundant-module-name
 

--- a/src/oca_pre_commit_hooks/base_checker.py
+++ b/src/oca_pre_commit_hooks/base_checker.py
@@ -59,12 +59,14 @@ class BaseChecker:
         enable: Set[str],
         disable: Set[str],
         module_name: Union[str, None] = None,
+        module_version: Union[str, None] = None,
         autofix: bool = False,
     ):
         self.enable = enable
         self.disable = disable
         self.autofix = autofix
         self.module_name = module_name
+        self.module_version = module_version
 
         self.checks_errors = []
         self.needs_autofix = False

--- a/src/oca_pre_commit_hooks/checks_odoo_module.py
+++ b/src/oca_pre_commit_hooks/checks_odoo_module.py
@@ -20,7 +20,7 @@ MANIFEST_NAMES = ("__openerp__.py", "__manifest__.py")
 
 class ChecksOdooModule(BaseChecker):
     def __init__(self, manifest_path, enable, disable, changed=None, verbose=True, autofix=False):
-        super().__init__(enable, disable, autofix=autofix)
+        super().__init__(enable, disable, autofix=autofix, module_version=utils.manifest_version(manifest_path))
         if not os.path.isfile(manifest_path) or os.path.basename(manifest_path) not in MANIFEST_NAMES:
             raise UserWarning(  # pragma: no cover
                 f"Not valid manifest file name {manifest_path} file expected {MANIFEST_NAMES}"
@@ -136,7 +136,7 @@ class ChecksOdooModule(BaseChecker):
         if not manifest_datas:
             return
         checks_obj = checks_odoo_module_xml.ChecksOdooModuleXML(
-            manifest_datas, self.odoo_addon_name, self.enable, self.disable
+            manifest_datas, self.odoo_addon_name, self.enable, self.disable, module_version=self.module_version
         )
         for check_meth in utils.getattr_checks(checks_obj):
             check_meth()

--- a/src/oca_pre_commit_hooks/utils.py
+++ b/src/oca_pre_commit_hooks/utils.py
@@ -2,11 +2,14 @@ import os
 import re
 import subprocess
 import sys
+from ast import literal_eval
 from contextlib import contextmanager
 from functools import lru_cache
 from inspect import getmembers, isfunction
 from itertools import chain
 from pathlib import Path
+
+from packaging.version import InvalidVersion, Version
 
 from oca_pre_commit_hooks.base_checker import BaseChecker
 
@@ -159,3 +162,16 @@ def get_checks_docstring(check_classes):
             checks_found |= set(re.findall(RE_CHECK_DOCSTRING, checks_docstring))
             checks_docstring = re.sub(r"( )+\*", "*", checks_docstring)
     return checks_found, checks_docstring
+
+
+def manifest_version(manifest_path):
+    with open(manifest_path, encoding="utf-8") as manifest_fd:
+        try:
+            manifest = literal_eval(manifest_fd.read())
+        except (ValueError, SyntaxError):
+            return None
+
+        try:
+            return Version(manifest.get("version"))
+        except InvalidVersion:
+            return None

--- a/test_repo/broken_module/model_view.xml
+++ b/test_repo/broken_module/model_view.xml
@@ -14,6 +14,10 @@
                     <xpath expr="//span[@t-esc='o.amount_to_text()']/.." position="after">
                         <attribute name="t-if">o.value</attribute>
                     </xpath>
+                    <div class="oe_chatter">
+                        <field name="message_follower_ids" groups="base.group_user"/>
+                        <field name="message_ids"/>
+                    </div>
                 </form>
             </field>
         </record>

--- a/test_repo/odoo18_module/__manifest__.py
+++ b/test_repo/odoo18_module/__manifest__.py
@@ -1,0 +1,12 @@
+{
+    'name': 'Odoo 18 Module For Tests',
+    'license': 'AGPL-3',
+    'author': 'Odoo Community Association (OCA)',
+    'version': '18.0.1.0.0',
+    'depends': [
+        'base',
+    ],
+    'data': [
+        'views/deprecated_chatter.xml',
+    ],
+}

--- a/test_repo/odoo18_module/views/deprecated_chatter.xml
+++ b/test_repo/odoo18_module/views/deprecated_chatter.xml
@@ -1,0 +1,11 @@
+<?xml version="1.0" encoding="utf-8" ?>
+<record id="deprecated_chatter" model="ir.ui.view">
+    <field name="name">deprecated.chatter.view</field>
+    <field name="model">random.model</field>
+    <field name="arch" type="xml">
+        <div class="oe_chatter">
+            <field name="message_follower_ids" groups="base.group_user"/>
+            <field name="message_ids"/>
+        </div>
+    </field>
+</record>

--- a/tests/test_checks.py
+++ b/tests/test_checks.py
@@ -37,6 +37,7 @@ EXPECTED_ERRORS = {
     "xml-oe-structure-missing-id": 6,
     "xml-record-missing-id": 2,
     "xml-duplicate-template-id": 9,
+    "xml-deprecated-oe-chatter": 1,
 }
 
 


### PR DESCRIPTION
A new check has been added to check for deprecated chatters in modules version 18 and above. For this new check it was also necessary to extract module version in order to selectively enable/disable the new check.

Closes #121.