### PR TITLE
WIP: [ADD] file-not-used: Detects files not used from manifest

### DIFF
--- a/README.md
+++ b/README.md
@@ -108,6 +108,9 @@ be disabled.
 
 # Checks
 
+* Check file-not-used
+Check if there is a file created but not referenced from __manifest__.py
+
 * Check manifest-syntax-error
 Check if the manifest file has syntax error
 
@@ -291,6 +294,10 @@ options:
  * csv-syntax-error
 
     - https://github.com/OCA/odoo-pre-commit-hooks/blob/v0.1.1/test_repo/syntax_err_module/ir.model.access.csv#L1 'utf-8' codec can't decode byte 0xf1 in position 47: invalid continuation byte
+
+ * file-not-used
+
+    - https://github.com/OCA/odoo-pre-commit-hooks/blob/v0.1.1//Users/moylop260/odoo/odoo-pre-commit-hooks/test_repo/broken_module/__openerp__.py#L1 File not used /Users/moylop260/odoo/odoo-pre-commit-hooks/test_repo/broken_module/report/test_report.xml
 
  * manifest-syntax-error
 

--- a/src/oca_pre_commit_hooks/checks_odoo_module.py
+++ b/src/oca_pre_commit_hooks/checks_odoo_module.py
@@ -130,6 +130,59 @@ class ChecksOdooModule(BaseChecker):
                 line=1,
             )
 
+    @staticmethod
+    def _get_files(path):
+        dirnames2include = [
+            "data",
+            "datas",
+            "demo",
+            "demos",
+            "report",
+            "reports",
+            "security",
+            "template",
+            "templates",
+            "view",
+            "views",
+            "wizard",
+            "wizards",
+        ]
+        manifest_data_extensions = [
+            ".csv",
+            ".xml",
+        ]
+        paths = set()
+        for root, _dirs, file_names in os.walk(path):
+            subfolders = os.path.relpath(root, path).split(os.sep)
+            if subfolders and subfolders[0] not in dirnames2include:
+                continue
+            for file_name in file_names:
+                if os.path.splitext(file_name)[1].lower() not in manifest_data_extensions:
+                    continue
+                full_path = os.path.join(root, file_name)
+                paths.add(full_path)
+        # TODO: Exclude files based on os.environ, config, disable comment or something else
+        return paths
+
+    @utils.only_required_for_checks("file-not-used")
+    def check_file_not_used(self):
+        """* Check file-not-used
+        Check if there is a file created but not referenced from __manifest__.py
+        """
+        manifest_files = set()
+        for _ext, manifest_referenced_files in self.manifest_referenced_files.items():
+            for manifest_referenced_file in manifest_referenced_files:
+                manifest_files.add(manifest_referenced_file["filename"])
+        addon_files = self._get_files(self.odoo_addon_path)
+        for file_not_used in addon_files - manifest_files:
+            self.register_error(
+                code="file-not-used",
+                message=f"File not used {file_not_used}",
+                info=self.error,
+                filepath=self.manifest_path,
+                line=1,
+            )
+
     @utils.only_required_for_installable()
     def check_xml(self):
         manifest_datas = self.manifest_referenced_files[".xml"]

--- a/tests/test_checks.py
+++ b/tests/test_checks.py
@@ -19,6 +19,7 @@ ALL_CHECK_CLASS = [
 EXPECTED_ERRORS = {
     "csv-duplicate-record-id": 1,
     "csv-syntax-error": 1,
+    "file-not-used": 1,
     "manifest-syntax-error": 2,
     "xml-create-user-wo-reset-password": 1,
     "xml-dangerous-filter-wo-user": 1,


### PR DESCRIPTION
Fix https://github.com/OCA/odoo-pre-commit-hooks/issues/74

- [ ] TODO: Disable check for exceptions
  - e.g. where the csv files were imported manually to speed-up and manifest doesn't have these files
     - https://github.com/odoo/enterprise/blob/e2a2adcaa82d855c4b13b5f39c291b181bc596ea/l10n_mx_edi_extended/hooks.py#L12 
- [ ] TODO: Compatible with windows