### PR TITLE
[FIX] checks_odoo_module_xml: return bytes from _get_first_tag

### DIFF
--- a/src/oca_pre_commit_hooks/checks_odoo_module_xml.py
+++ b/src/oca_pre_commit_hooks/checks_odoo_module_xml.py
@@ -117,7 +117,7 @@ class ChecksOdooModuleXML(BaseChecker):
                 if line_stripped not in buffer:
                     buffer.append(line_stripped)
                 return b" ".join(buffer), buffer_lineno
-        return "", 0
+        return b"", 0
 
     def update_node(self, manifest_data):
         """Update the etree node of the manifest_data.


### PR DESCRIPTION
## Problem

When an XML file in the inspected module contains no tag (e.g. an empty `.xml` file), `ChecksOdooModuleXML._get_first_tag` returns the Python `str` `''`. The success branch of the same method returns bytes from `b' '.join(buffer)`, and downstream code in `check_xml_header` consumes the result as bytes:

```python
if not first_tag.startswith(b"<?xml "):
```

When `first_tag` is `str`, `startswith(bytes)` raises:

```
TypeError: startswith first arg must be str or a tuple of str, not bytes
```

This crashes the entire hook for the repository as soon as one empty/tag-less XML file exists anywhere in the inspected modules — even if `xml-header-missing` is disabled, because the mismatch happens before the enablement check.

## Reproduction

```python
import io
from oca_pre_commit_hooks.checks_odoo_module_xml import ChecksOdooModuleXML

inst = ChecksOdooModuleXML.__new__(ChecksOdooModuleXML)
result = inst._get_first_tag(io.BytesIO(b''))
# Before fix: ('', 0) — str
# After fix:  (b'', 0) — bytes
```

The existing `test_repo/broken_module/xml_empty.xml` fixture is a 0-byte file and reproduces the issue on real hook runs.

## Fix

Return `b""` instead of `""` in the no-tag path so both branches of `_get_first_tag` are type-consistent (always bytes), and downstream `startswith(b"<?xml ")` / `decode("UTF-8")` calls keep working.

One-line change in `src/oca_pre_commit_hooks/checks_odoo_module_xml.py`.

## Notes

Found while running v0.2.20 against an Odoo 19 addon that contains an empty XML file. The local test suite does not run on Python 3.14 (distutils removed) so verification was done via targeted reproduction; CI will validate against the supported matrix.