### PR TITLE
[ADD] xml-deprecated-css-class

### DIFF
--- a/src/oca_pre_commit_hooks/checks_odoo_module_xml.py
+++ b/src/oca_pre_commit_hooks/checks_odoo_module_xml.py
@@ -79,6 +79,33 @@ class ChecksOdooModuleXML(BaseChecker):
     xpath_xpath = etree.XPath("//xpath")
     xpath_oe_chatter = etree.XPath("//div[hasclass('oe_chatter')]")
 
+    # Mapping ``{deprecated_class: replacement}`` for ``check_xml_deprecated_css_class``.
+    # Each entry is a one-to-one substitution that does not depend on the
+    # element's tag, parent, or surrounding markup. Ambiguous cases (e.g.
+    # ``oe_inline``, where the BS5 replacement depends on context) are
+    # intentionally omitted.
+    deprecated_css_classes = {
+        # Bootstrap 3 → 5 utility renames. Odoo bundles Bootstrap 5 since
+        # version 15.0.
+        "pull-left": "float-start",
+        "pull-right": "float-end",
+        "panel": "card",
+        "panel-default": "card",
+        "panel-heading": "card-header",
+        "panel-body": "card-body",
+        "panel-title": "card-title",
+        "panel-footer": "card-footer",
+        "img-responsive": "img-fluid",
+        "btn-default": "btn-secondary",
+        # Odoo legacy classes that were superseded by BS5 utilities.
+        "oe_left": "float-start",
+        "oe_right": "float-end",
+        "oe_grey": "text-muted",
+    }
+    xpath_deprecated_css_class = {
+        css_class: etree.XPath(f"//*[hasclass('{css_class}')]") for css_class in deprecated_css_classes
+    }
+
     tree_deprecate_attrs = {"string", "colors", "fonts"}
     xpath_tree_deprecated = etree.XPath(f'.//tree[{"|".join(f"@{a}" for a in tree_deprecate_attrs)}]')
 
@@ -926,3 +953,37 @@ class ChecksOdooModuleXML(BaseChecker):
                     filepath=manifest_data["filename_short"],
                     line=xpath_node.sourceline,
                 )
+
+    @utils.only_required_for_checks("xml-deprecated-css-class")
+    def check_xml_deprecated_css_class(self):
+        """* Check xml-deprecated-css-class
+
+        Detect legacy CSS classes in XML / QWeb views and suggest the
+        modern replacement. Two sources are covered:
+
+        * Bootstrap 3 utility classes that were renamed in Bootstrap 5.
+          Odoo bundles Bootstrap 5 since version 15.0, so any module
+          targeting 15.0+ should drop the legacy names.
+        * Odoo legacy classes (``oe_left``, ``oe_right``, ``oe_grey``)
+          that were superseded by Bootstrap 5 utilities.
+
+        Only unambiguous one-to-one mappings are flagged here; ambiguous
+        classes (``oe_inline``, ``oe_button_box``, …) are left out so the
+        rule can be enabled without manual review of every hit.
+        """
+        if not self.module_version or (self.module_version and self.module_version < Version("15")):
+            return
+
+        for manifest_data in self.manifest_datas:
+            for css_class, replacement in self.deprecated_css_classes.items():
+                xpath = self.xpath_deprecated_css_class[css_class]
+                for xpath_node in xpath(manifest_data["node"]):
+                    self.register_error(
+                        code="xml-deprecated-css-class",
+                        message=(
+                            f"Deprecated CSS class {css_class!r}; "
+                            f"replace with {replacement!r}."
+                        ),
+                        filepath=manifest_data["filename_short"],
+                        line=xpath_node.sourceline,
+                    )

--- a/test_repo/odoo18_module/__manifest__.py
+++ b/test_repo/odoo18_module/__manifest__.py
@@ -8,6 +8,7 @@
     ],
     'data': [
         'views/deprecated_chatter.xml',
+        'views/deprecated_css_class.xml',
         'views/deprecated_qweb_directives15.xml',
     ],
 }

--- a/test_repo/odoo18_module/views/deprecated_css_class.xml
+++ b/test_repo/odoo18_module/views/deprecated_css_class.xml
@@ -1,4 +1,4 @@
-<?xml version="1.0" encoding="utf-8" ?>
+<?xml version="1.0" encoding="UTF-8" ?>
 <record id="deprecated_css_class_view" model="ir.ui.view">
     <field name="name">deprecated.css.view</field>
     <field name="model">random.model</field>

--- a/test_repo/odoo18_module/views/deprecated_css_class.xml
+++ b/test_repo/odoo18_module/views/deprecated_css_class.xml
@@ -1,0 +1,20 @@
+<?xml version="1.0" encoding="utf-8" ?>
+<record id="deprecated_css_class_view" model="ir.ui.view">
+    <field name="name">deprecated.css.view</field>
+    <field name="model">random.model</field>
+    <field name="arch" type="xml">
+        <form>
+            <div class="pull-right">Right-floated content</div>
+            <div class="panel panel-default">
+                <div class="panel-heading"><h3 class="panel-title">Title</h3></div>
+                <div class="panel-body">Body</div>
+                <div class="panel-footer">Footer</div>
+            </div>
+            <img src="logo.png" class="img-responsive"/>
+            <button class="btn btn-default">Cancel</button>
+            <div class="oe_left">Old-style left</div>
+            <div class="oe_right">Old-style right</div>
+            <span class="oe_grey">Faded label</span>
+        </form>
+    </field>
+</record>

--- a/tests/test_checks.py
+++ b/tests/test_checks.py
@@ -53,6 +53,7 @@ EXPECTED_ERRORS = {
     "xml-header-missing": 2,
     "xml-header-wrong": 18,
     "xml-id-position-first": 9,
+    "xml-deprecated-css-class": 12,
     "xml-deprecated-oe-chatter": 1,
     "xml-field-bool-without-eval": 2,
     "xml-field-numeric-without-eval": 7,


### PR DESCRIPTION
## Summary

Adds a new check, `xml-deprecated-css-class`, that detects legacy CSS classes in XML / QWeb view files and suggests the modern replacement. Each hit emits a single warning with the exact line number and the recommended substitution.

## Why

Real-world OCA repositories still carry a long tail of Bootstrap 3 utility classes that Odoo silently broke when bundling Bootstrap 5 (since version 15.0), plus a handful of Odoo legacy `oe_*` classes that have direct BS5 replacements. A representative audit across one private deployment and a sample of OCA repos shows:

| Class | Total hits |
|---|---|
| `btn-default` | 114 |
| `panel` / `panel-*` (combined) | 23 |
| `oe_grey` | 23 |
| `oe_right` | 22 |
| `pull-right` | 14 |
| `pull-left` | 2 |

(`oe_inline` (829), `oe_button_box` (258), `oe_edit_only` (246) are also widespread but **not** flagged here because their replacements depend on context — they need their own checks with structural logic.)

## What's covered

Only **unambiguous one-to-one** mappings, so the rule can be enabled without manual review of every hit:

- Bootstrap 3 → 5 utility renames:
  `pull-left → float-start`, `pull-right → float-end`,
  `panel → card`, `panel-default → card`, `panel-heading → card-header`,
  `panel-body → card-body`, `panel-title → card-title`, `panel-footer → card-footer`,
  `img-responsive → img-fluid`, `btn-default → btn-secondary`.
- Odoo legacy → BS5 utility:
  `oe_left → float-start`, `oe_right → float-end`, `oe_grey → text-muted`.

Each entry lives in a single `deprecated_css_classes` dict on `ChecksOdooModuleXML`, so adding more mappings later is a one-line change.

## Version gating

The check fires only when `self.module_version >= 15.0`, mirroring `xml-deprecated-oe-chatter`'s gating pattern. Modules targeting older Odoo versions are left alone — Bootstrap 3 is still legitimate there.

## Tests

- New fixture `test_repo/odoo18_module/views/deprecated_css_class.xml` exercising all 13 mapping entries (12 hits — `panel-default` co-occurs with `panel` on the same line, so two warnings on one element).
- `EXPECTED_ERRORS` updated: `"xml-deprecated-css-class": 12`.
- Verified locally via the CLI on the fixture — every hit lands on the right line, with the right replacement string.

## Not in scope

- Ambiguous-replacement classes (`oe_inline`, `oe_button_box`, `oe_edit_only`, `hidden-xs/sm/md/lg`, `well`, `glyphicon-*`). Each of these wants its own context-aware check; that's better as a follow-up than padding this PR with rules that need manual review.
- Auto-fix. The hook reports; the developer fixes. (Auto-fix could land later under `cli_fixit.py`.)