### PR TITLE
[ADD] no-translation-format: Do not use `format` with translations

### DIFF
--- a/README.md
+++ b/README.md
@@ -122,6 +122,19 @@ Check if there is a file created but not referenced from __manifest__.py
 * Check manifest-syntax-error
 Check if the manifest file has syntax error
 
+* Check no-translation-format
+Check if a translation is interpolated using `str.format`.
+`str.format` should not be used to interpolate translations
+because it allows a translator to execute arbitrary code, like:
+
+```
+>>> 'class of {0} is {0.__class__}'.format(42)
+"class of 42 is <class 'int'>"
+
+```
+
+See https://lucumr.pocoo.org/2016/12/29/careful-with-str-format for a more detailed explanation.
+
 * Check prefer-readme-rst
 Check if the module has README.md file to prefer README.rst file
 
@@ -404,6 +417,12 @@ options:
 
     - https://github.com/OCA/odoo-pre-commit-hooks/blob/v0.2.22/test_repo/manifest_werror/__manifest__.py#L1 Manifest could not be loaded manifest malformed
     - https://github.com/OCA/odoo-pre-commit-hooks/blob/v0.2.22/test_repo/woinit_module/__manifest__.py#L1 Manifest could not be loaded
+
+ * no-translation-format
+
+    - https://github.com/OCA/odoo-pre-commit-hooks/blob/v0.2.22/test_repo/broken_module/models/broken_model.py#L275 Format is used to interpolate translations, use the args/kwargs of `_` instead.
+    - https://github.com/OCA/odoo-pre-commit-hooks/blob/v0.2.22/test_repo/broken_module/models/broken_model.py#L283 Format is used to interpolate translations, use the args/kwargs of `_` instead.
+    - https://github.com/OCA/odoo-pre-commit-hooks/blob/v0.2.22/test_repo/broken_module/models/broken_model.py#L389 Format is used to interpolate translations, use the args/kwargs of `_` instead.
 
  * prefer-env-translation
 

--- a/src/oca_pre_commit_hooks/checks_odoo_module.py
+++ b/src/oca_pre_commit_hooks/checks_odoo_module.py
@@ -180,6 +180,39 @@ class ChecksOdooModule(BaseChecker):
             line=1,
         )
 
+    @utils.only_required_for_installable()
+    @utils.only_required_for_checks("no-translation-format")
+    def check_no_translation_format(self):
+        """* Check no-translation-format
+        Check if a translation is interpolated using `str.format`.
+        `str.format` should not be used to interpolate translations
+        because it allows a translator to execute arbitrary code, like:
+
+        ```
+        >>> 'class of {0} is {0.__class__}'.format(42)
+        "class of 42 is <class 'int'>"
+
+        ```
+
+        See https://lucumr.pocoo.org/2016/12/29/careful-with-str-format for a more detailed explanation.
+        """
+
+        def is_translation_function_call(ast_node):
+            return isinstance(ast_node, ast.Call) and isinstance(ast_node.func, ast.Name) and ast_node.func.id == "_"
+
+        for py_file_path in Path(self.odoo_addon_path).rglob("*.py"):
+            parsed = ast.parse(py_file_path.read_bytes())
+            for node in ast.walk(parsed):
+                for child in ast.iter_child_nodes(node):
+                    if is_translation_function_call(child) and getattr(node, "attr", None) == "format":
+                        self.register_error(
+                            code="no-translation-format",
+                            message="Format is used to interpolate translations, use the args/kwargs of `_` instead.",
+                            filepath=os.path.relpath(py_file_path, self.manifest_top_path),
+                            line=node.lineno,
+                            column=node.col_offset,
+                        )
+
     @staticmethod
     def _get_module_data_files(module_root_path):
         module_root_path_obj = Path(module_root_path).resolve()

--- a/tests/test_checks.py
+++ b/tests/test_checks.py
@@ -26,6 +26,7 @@ EXPECTED_ERRORS = {
     "file-not-used": 1,
     "manifest-superfluous-key": 3,
     "manifest-syntax-error": 2,
+    "no-translation-format": 3,
     "prefer-env-translation": 39,
     "prefer-readme-rst": 1,
     "unused-logger": 1,


### PR DESCRIPTION
The check was added in https://github.com/OCA/pylint-odoo/pull/304, then has been removed in https://github.com/OCA/pylint-odoo/pull/396 because it was supposedly checked by https://github.com/OCA/odoo-pre-commit-hooks, but I can't find such check.

@moylop260 looks like you are involved in all the related changes, please let me know what you think.