### PR TITLE
[IMP] fixit: Disable nested parallelism under pre-commit to run ~5x faster

### DIFF
--- a/.coveragerc
+++ b/.coveragerc
@@ -5,6 +5,9 @@ source = src
 source = src
 parallel = true
 context = ${{COVERAGE_CONTEXT}}
+# "sysmon" is the default core since python3.14 but it does not support the dynamic
+# contexts set by "pytest --cov-context=test" raising a CoverageWarning for each test
+core = ctrace
 
 [report]
 show_missing = true

--- a/.pre-commit-hooks.yaml
+++ b/.pre-commit-hooks.yaml
@@ -14,7 +14,10 @@
 - id: oca-checks-odoo-module-fixit
   name: Checks for py files of Odoo modules with fixit
   description: Multiple checks for Odoo modules with autofixes
-  entry: oca-checks-odoo-module-fixit
+  # --no-expand-manifest: pre-commit passes exactly the changed files, so a chunk
+  # containing only the manifest must not re-scan the whole module (another concurrent
+  # chunked invocation may already be processing the sibling files)
+  entry: oca-checks-odoo-module-fixit --no-expand-manifest
   args: []
   language: python
   types_or: ["python"]

--- a/src/oca_pre_commit_hooks/checks_odoo_module_fixit.py
+++ b/src/oca_pre_commit_hooks/checks_odoo_module_fixit.py
@@ -3,6 +3,7 @@ import ast
 import os
 import sys
 from collections import defaultdict
+from concurrent.futures import ProcessPoolExecutor
 from functools import lru_cache
 from itertools import chain
 from pathlib import Path
@@ -18,8 +19,18 @@ MANIFEST_NAMES = ("__openerp__.py", "__manifest__.py")
 
 
 class ChecksOdooModuleFixit(BaseChecker):
-    def __init__(self, manifest_path, enable, disable, changed=None, verbose=True, autofix=False):
+    def __init__(
+        self,
+        manifest_path,
+        enable,
+        disable,
+        changed=None,
+        verbose=True,
+        autofix=False,
+        expand_manifest=True,
+    ):
         super().__init__(enable, disable, autofix=autofix, module_version=utils.manifest_version(manifest_path))
+        self.expand_manifest = expand_manifest
         manifest_path_obj = Path(manifest_path)
         if not manifest_path_obj.is_file() or manifest_path_obj.name not in MANIFEST_NAMES:
             raise UserWarning(  # pragma: no cover
@@ -86,9 +97,10 @@ class ChecksOdooModuleFixit(BaseChecker):
             curr_path = Path(f_path)
             changed |= {curr_path}
         manifest_path = Path(self.manifest_path)
-        if changed == {manifest_path}:
-            # Compatible with current way using only the manifest file for the whole module
-            # TODO: Use file by file to use jobs in pre-commit
+        if self.expand_manifest and changed == {manifest_path}:
+            # Legacy CLI behavior: passing only the manifest means checking the whole module
+            # pre-commit passes --no-expand-manifest since it sends exactly the changed files
+            # and another concurrent chunked invocation may already be processing the sibling files
             changed = {manifest_path.parent}
         if {manifest_path.parent} & changed:
             # Manifest is not imported from __init__.py so it is included manually
@@ -123,7 +135,7 @@ class ChecksOdooModuleFixit(BaseChecker):
                         paths=[manifest_path],
                         options=manifest_options,
                         autofix=self.autofix,
-                        parallel=not self.autofix,  # Fixit parallel is not compatible with autofix
+                        parallel=False,
                     )
                 )
             if lint_rules_enabled_all and self.changed:
@@ -133,7 +145,10 @@ class ChecksOdooModuleFixit(BaseChecker):
                         paths=changed,
                         options=all_options,
                         autofix=self.autofix,
-                        parallel=not self.autofix,  # Fixit parallel is not compatible with autofix
+                        # fixit's own pool is never worth it here: the concurrency comes from
+                        # pre-commit chunked invocations or from the per-module pool in run()
+                        # and a nested pool per module only pays spawn+import overhead
+                        parallel=False,
                     )
                 )
             for result in chain.from_iterable(results):
@@ -235,6 +250,22 @@ def lookup_manifest_paths(filenames_or_modules):
     return odoo_module_files_changed
 
 
+def _run_manifest_checks(manifest_path, changed, enable, disable, no_verbose, autofix, no_expand_manifest):
+    """Run all the checks of a single Odoo module (also used as a process pool task)"""
+    checks_obj = ChecksOdooModuleFixit(
+        Path(manifest_path).resolve().as_posix(),
+        enable,
+        disable,
+        changed=changed,
+        verbose=not no_verbose,
+        autofix=autofix,
+        expand_manifest=not no_expand_manifest,
+    )
+    for check in utils.getattr_checks(checks_obj):
+        check()
+    return checks_obj.checks_errors
+
+
 def run(
     files_or_modules,
     enable=None,
@@ -244,6 +275,7 @@ def run(
     list_msgs=False,
     autofix=False,
     xml_attributes_order=None,
+    no_expand_manifest=False,
 ):
     # pylint: disable=duplicate-code
     if list_msgs:
@@ -264,21 +296,23 @@ def run(
     if disable is None:
         disable = set()
     exit_status = 0
-    for manifest_path, changed in lookup_manifest_paths(files_or_modules).items():
-        if not manifest_path:
-            continue
-        checks_obj = ChecksOdooModuleFixit(
-            Path(manifest_path).resolve().as_posix(),
-            enable,
-            disable,
-            changed=changed,
-            verbose=not no_verbose,
-            autofix=autofix,
-        )
-        for check in utils.getattr_checks(checks_obj):
-            check()
-        if checks_obj.checks_errors:
-            all_check_errors.extend(checks_obj.checks_errors)
+    check_args = [
+        (manifest_path, changed, enable, disable, no_verbose, autofix, no_expand_manifest)
+        for manifest_path, changed in lookup_manifest_paths(files_or_modules).items()
+        if manifest_path
+    ]
+    # pre-commit exports PRE_COMMIT=1 and already runs ~cpu_count concurrent chunked
+    # invocations (require_serial: false) so a pool there would only oversubscribe the CPU
+    # A standalone CLI invocation instead processes the independent modules concurrently
+    if len(check_args) > 1 and "PRE_COMMIT" not in os.environ:
+        with ProcessPoolExecutor() as executor:
+            futures = [executor.submit(_run_manifest_checks, *args) for args in check_args]
+            all_module_errors = [future.result() for future in futures]
+    else:
+        all_module_errors = [_run_manifest_checks(*args) for args in check_args]
+    for checks_errors in all_module_errors:
+        if checks_errors:
+            all_check_errors.extend(checks_errors)
             exit_status = 1
     # Sort errors by filepath, line, column and code
     all_check_errors.sort()

--- a/src/oca_pre_commit_hooks/cli_fixit.py
+++ b/src/oca_pre_commit_hooks/cli_fixit.py
@@ -24,6 +24,13 @@ def main(argv=None):
         nargs="*",
         help="Odoo __manifest__.py paths or Odoo module paths.",
     )
+    parser.add_argument(
+        "--no-expand-manifest",
+        action="store_true",
+        default=False,
+        help="Do not expand a manifest-only path to the whole module directory. Recommended for "
+        "pre-commit, which passes exactly the changed files.",
+    )
     if argv is None:
         argv = sys.argv[1:]
     kwargs = vars(parser.parse_args(argv))

--- a/src/oca_pre_commit_hooks/utils.py
+++ b/src/oca_pre_commit_hooks/utils.py
@@ -231,27 +231,50 @@ def chdir(directory):
         os.chdir(original_dir)
 
 
-@lru_cache(maxsize=256)
+# Cache of the top level path resolved for each path already visited and
+# set of the top level paths already found containing a ".git" entry
+_top_path_cache = {}
+_known_top_paths = set()
+
+
 def top_path(path):
-    """Get the top level path based on git
+    """Get the top level path based on the first parent path containing a ".git"
+    entry (a directory for regular repositories or a file for submodules and worktrees)
     If no git repository is found (and therefore no top level path), the user's HOME is returned.
 
-    It is using lru_cache in order to re-use top level path values
-    if multiple files are sharing the same path
+    It looks for the ".git" entry instead of running "git rev-parse --show-toplevel"
+    since that spawning a subprocess per directory was a significant slice of the
+    whole runtime (py-spy profiled)
+
+    The values are cached and the children paths of a top level path already found
+    re-use it directly based on the path prefix so they are resolved without
+    checking ".git" for each parent path again
 
     Notice it is not compatible with TemporaryDirectory since that it needs to have a .git folder
     but you can fix it using "git init"
     """
-    try:
-        with chdir(path):
-            return (
-                subprocess.check_output(["git", "rev-parse", "--show-toplevel"], stderr=subprocess.STDOUT)
-                .decode(sys.stdout.encoding)
-                .strip()
-            )
-    except (FileNotFoundError, subprocess.CalledProcessError):
-        path = Path(path)
-        return path.root or Path.home()
+    path = str(path)
+    top = _top_path_cache.get(path)
+    if top is not None:
+        return top
+    path_obj = full_norm_path_obj(path)
+    for known_top_path in _known_top_paths:
+        if path_obj.is_relative_to(known_top_path):
+            _top_path_cache[path] = known_top_path
+            return known_top_path
+    if (path_obj / ".git").exists():
+        # Native separators (not "as_posix()") to match the rest of the codebase,
+        # which builds and compares paths with "os.path" using the OS separator
+        top = str(path_obj)
+        _known_top_paths.add(top)
+    else:
+        parent_path = path_obj.parent
+        if parent_path == path_obj:
+            top = path_obj.root or str(Path.home())
+        else:
+            top = top_path(str(parent_path))
+    _top_path_cache[path] = top
+    return top
 
 
 @lru_cache(maxsize=64)
@@ -277,23 +300,61 @@ def repo_name(path):
         return ""
 
 
+def full_norm_path_obj(path):
+    """Expand paths in all possible ways returning a "Path" object
+    "Path.resolve()" replaces the previous abspath + realpath + normpath chain in a
+    single call since it already returns an absolute path resolving the symlinks and
+    normalizing the parent references ("os.path.expandvars" is kept because pathlib
+    does not provide an equivalent)
+    """
+    return Path(os.path.expandvars(str(path).strip())).expanduser().resolve()
+
+
 def full_norm_path(path):
     """Expand paths in all possible ways"""
-    return os.path.normpath(os.path.realpath(os.path.abspath(os.path.expanduser(os.path.expandvars(path.strip())))))
+    return str(full_norm_path_obj(path))
 
 
-@lru_cache(maxsize=256)
+# Cache of the results already resolved by path, filenames and top and the
+# parent paths where one of the filenames was already found by filenames
+_walk_up_cache = {}
+_known_walk_up_dirs = {}
+
+
 def walk_up(path, filenames, top):
     """Look for "filenames" walking up in parent paths of "path"
     but limited only to "top" path
+    The results are cached and the children paths of a parent path where one of
+    the filenames was already found re-use it directly without checking the
+    filesystem for each parent path again
     """
-    if full_norm_path(path) == full_norm_path(top):
-        return None
-    for filename in filenames:
-        path_filename = os.path.join(path, filename)
-        if os.path.isfile(full_norm_path(path_filename)):
-            return path_filename
-    return walk_up(os.path.dirname(path), filenames, top)
+    cache_key = (path, filenames, top)
+    try:
+        return _walk_up_cache[cache_key]
+    except KeyError:
+        pass
+    known_dirs = _known_walk_up_dirs.setdefault(filenames, {})
+    path_obj = Path(path)
+    result = None
+    for parent_path in (path_obj, *path_obj.parents):
+        result = known_dirs.get((str(parent_path), top))
+        if result is not None:
+            break
+    if result is None:
+        top_norm_path = full_norm_path_obj(top)
+        current_path = path_obj
+        while full_norm_path_obj(current_path) != top_norm_path:
+            for filename in filenames:
+                path_filename = current_path / filename
+                if full_norm_path_obj(path_filename).is_file():
+                    result = str(path_filename)
+                    known_dirs[(str(current_path), top)] = result
+                    break
+            if result is not None or current_path.parent == current_path:
+                break
+            current_path = current_path.parent
+    _walk_up_cache[cache_key] = result
+    return result
 
 
 def fixit_parse_rule():

--- a/tests/common.py
+++ b/tests/common.py
@@ -15,6 +15,10 @@ from oca_pre_commit_hooks.global_parser import CONFIG_NAME, DISABLE_ENV_VAR, ENA
 
 RND = random.Random(987654321)
 
+# Simulate the pre-commit environment (see checks_odoo_module_fixit.check_py_fixit):
+# without it every run() call would spawn a fixit process pool slowing down the whole suite
+os.environ.setdefault("PRE_COMMIT", "1")
+
 
 def assertDictEqual(self, d1, d2, msg=None):
     # pylint:disable=invalid-name

--- a/tests/test_checks.py
+++ b/tests/test_checks.py
@@ -10,6 +10,16 @@ from pathlib import Path
 import pytest
 
 import oca_pre_commit_hooks
+
+# Import the submodules explicitly to bind them as package attributes since
+# the package __init__ does not import them and the attribute accesses below
+# would otherwise depend on the import side effects of other test modules
+import oca_pre_commit_hooks.checks_odoo_module
+import oca_pre_commit_hooks.checks_odoo_module_csv
+import oca_pre_commit_hooks.checks_odoo_module_fixit
+import oca_pre_commit_hooks.checks_odoo_module_xml
+import oca_pre_commit_hooks.cli
+import oca_pre_commit_hooks.cli_fixit
 import oca_pre_commit_hooks.global_parser
 from . import common
 

--- a/tests/test_checks_po.py
+++ b/tests/test_checks_po.py
@@ -9,6 +9,10 @@ from tempfile import TemporaryDirectory
 import pytest
 
 import oca_pre_commit_hooks
+
+# Explicit submodule imports to bind them as package attributes (see test_checks.py)
+import oca_pre_commit_hooks.checks_odoo_module_po
+import oca_pre_commit_hooks.cli_po
 from . import common
 
 RE_CHECK_DOCSTRING = r"\* Check (?P<check>[\w|\-]+)"

--- a/tests/test_fixit_flags.py
+++ b/tests/test_fixit_flags.py
@@ -1,0 +1,96 @@
+import os
+import shutil
+import tempfile
+from pathlib import Path
+
+import pytest
+
+import oca_pre_commit_hooks.checks_odoo_module_fixit
+from . import common
+
+MANIFEST_ONLY_CODES = {"manifest-superfluous-key": 2}
+WHOLE_MODULE_CODES = {
+    "manifest-superfluous-key": 2,
+    "field-string-redundant": 30,
+    "prefer-env-translation": 39,
+    "unused-logger": 1,
+}
+
+
+class TestFixitFlags:
+    @classmethod
+    def setup_class(cls):
+        cls.original_test_repo_path = os.path.join(
+            os.path.dirname(os.path.dirname(os.path.realpath(__file__))), "test_repo"
+        )
+
+    def setup_method(self, method):
+        self.tmp_dir = os.path.realpath(tempfile.mkdtemp(suffix="_oca_pre_commit_hooks"))
+        common.create_dummy_repo(self.original_test_repo_path, self.tmp_dir)
+        self.manifest_path = os.path.join(self.tmp_dir, "broken_module", "__openerp__.py")
+
+    def teardown_method(self, method):
+        if os.path.isdir(self.tmp_dir) and self.tmp_dir != "/":
+            shutil.rmtree(self.tmp_dir, ignore_errors=True)
+
+    @staticmethod
+    def get_count_code_errors(all_check_errors):
+        return common.ChecksCommon.get_count_code_errors(all_check_errors)
+
+    def test_manifest_expands_to_whole_module_by_default(self):
+        all_check_errors = oca_pre_commit_hooks.checks_odoo_module_fixit.run(
+            [self.manifest_path], no_exit=True, no_verbose=True
+        )
+        assert self.get_count_code_errors(all_check_errors) == WHOLE_MODULE_CODES
+
+    def test_standalone_parallel_matches_precommit_serial(self):
+        """Without PRE_COMMIT in the environment the modules are processed by a process
+        pool and must report the same errors as the serial pre-commit path"""
+        manifest_paths = [self.manifest_path, os.path.join(self.tmp_dir, "eleven_module", "__manifest__.py")]
+        expected_errors = dict(WHOLE_MODULE_CODES, **{"use-header-comments": 1})
+        serial_errors = oca_pre_commit_hooks.checks_odoo_module_fixit.run(
+            manifest_paths, no_exit=True, no_verbose=True
+        )
+        assert self.get_count_code_errors(serial_errors) == expected_errors
+        mp = pytest.MonkeyPatch()
+        mp.delenv("PRE_COMMIT", raising=False)
+        try:
+            parallel_errors = oca_pre_commit_hooks.checks_odoo_module_fixit.run(
+                manifest_paths, no_exit=True, no_verbose=True
+            )
+        finally:
+            mp.undo()
+        assert sorted(parallel_errors) == sorted(serial_errors)
+
+    def test_no_expand_manifest_checks_only_the_manifest(self):
+        all_check_errors = oca_pre_commit_hooks.checks_odoo_module_fixit.run(
+            [self.manifest_path], no_exit=True, no_verbose=True, no_expand_manifest=True
+        )
+        assert self.get_count_code_errors(all_check_errors) == MANIFEST_ONLY_CODES
+
+    def test_no_expand_manifest_with_sibling_files(self):
+        """When more files than the manifest are passed only those files are checked, same as before"""
+        model_path = os.path.join(self.tmp_dir, "broken_module", "models", "broken_model.py")
+        all_check_errors = oca_pre_commit_hooks.checks_odoo_module_fixit.run(
+            [self.manifest_path, model_path], no_exit=True, no_verbose=True, no_expand_manifest=True
+        )
+        codes = self.get_count_code_errors(all_check_errors)
+        assert codes["manifest-superfluous-key"] == MANIFEST_ONLY_CODES["manifest-superfluous-key"]
+        assert set(codes) - {"manifest-superfluous-key"}, "Expected file-level errors from the sibling file"
+
+    def test_autofix_applies_fixes(self):
+        original_contents = {
+            py_file: py_file.read_bytes() for py_file in (Path(self.tmp_dir) / "broken_module").rglob("*.py")
+        }
+        errors_autofix = oca_pre_commit_hooks.checks_odoo_module_fixit.run(
+            [self.manifest_path], no_exit=True, no_verbose=True, autofix=True
+        )
+        assert self.get_count_code_errors(errors_autofix) == WHOLE_MODULE_CODES
+        assert any(
+            py_file.read_bytes() != content for py_file, content in original_contents.items()
+        ), "Autofix did not modify any file"
+        errors_after = oca_pre_commit_hooks.checks_odoo_module_fixit.run(
+            [self.manifest_path], no_exit=True, no_verbose=True
+        )
+        remaining = self.get_count_code_errors(errors_after)
+        assert set(remaining) < set(WHOLE_MODULE_CODES), f"Autofixable errors still present: {remaining}"

--- a/tests/test_utils.py
+++ b/tests/test_utils.py
@@ -1,0 +1,53 @@
+import os
+from pathlib import Path
+from tempfile import TemporaryDirectory
+
+from oca_pre_commit_hooks import utils
+from oca_pre_commit_hooks.checks_odoo_module_fixit import MANIFEST_NAMES
+
+
+class TestUtils:
+    def test_top_path(self):
+        """Test the top level path is inferred from the first parent path containing a ".git" entry"""
+        with TemporaryDirectory() as tmp_dir:
+            tmp_dir = os.path.realpath(tmp_dir)
+            repo_path = os.path.join(tmp_dir, "repo")
+            module_path = os.path.join(repo_path, "module", "models")
+            os.makedirs(module_path)
+            os.makedirs(os.path.join(repo_path, ".git"))
+            assert utils.top_path(module_path) == repo_path
+            assert utils.top_path(repo_path) == repo_path
+            # A child of a top level path already found re-uses it directly
+            # based on the path prefix without checking ".git" again
+            nested_repo_path = os.path.join(module_path, "nested_repo")
+            os.makedirs(os.path.join(nested_repo_path, ".git"))
+            assert utils.top_path(nested_repo_path) == repo_path
+            # Without a .git parent path the top is the root or the user's HOME
+            no_repo_path = os.path.join(tmp_dir, "no_repo")
+            os.makedirs(no_repo_path)
+            assert utils.top_path(no_repo_path) == (Path(no_repo_path).root or str(Path.home()))
+
+    def test_walk_up(self):
+        """Test the manifest is found walking up limited by the top path"""
+        with TemporaryDirectory() as tmp_dir:
+            tmp_dir = os.path.realpath(tmp_dir)
+            repo_path = os.path.join(tmp_dir, "repo")
+            module_path = os.path.join(repo_path, "module")
+            models_path = os.path.join(module_path, "models")
+            os.makedirs(models_path)
+            os.makedirs(os.path.join(repo_path, ".git"))
+            manifest_path = os.path.join(module_path, "__manifest__.py")
+            with open(manifest_path, "w", encoding="utf-8") as f_manifest:
+                f_manifest.write("{}")
+            top = utils.top_path(models_path)
+            assert top == repo_path
+            assert utils.walk_up(models_path, MANIFEST_NAMES, top) == manifest_path
+            # A child of a parent path where the manifest was already found
+            # re-uses it directly without checking the filesystem again
+            wizards_path = os.path.join(module_path, "wizards")
+            os.makedirs(wizards_path)
+            assert utils.walk_up(wizards_path, MANIFEST_NAMES, top) == manifest_path
+            # No manifest between the path and the top
+            other_path = os.path.join(repo_path, "other")
+            os.makedirs(other_path)
+            assert utils.walk_up(other_path, MANIFEST_NAMES, top) is None


### PR DESCRIPTION
The fixit hook ran with `parallel=not autofix` inside each invocation, but pre-commit already partitions the file list across ~cpu_count concurrent invocations (`require_serial: false`). Nesting fixit's process pool inside each chunk oversubscribed the CPU (~144 spawned processes re-importing libcst), making the default lint mode ~5.5x slower than running serial per chunk.

Benchmark on a 12-core machine with 3 modules x 40 files (~3600 violations):

| Configuration | Lint | Autofix |
|---|---|---|
| pre-commit chunks + fixit serial (**new**) | **6.0s** | **6.8s** |
| pre-commit chunks + fixit parallel (old lint) | 33.1s | 44.3s |
| single invocation + fixit parallel | 9.5s | 12.2s |
| single invocation + fixit serial (old autofix) | 36.7s | 37.1s |

The old comment "Fixit parallel is not compatible with autofix" is outdated: fixit only restricts *interactive* fixes (`generator.send()`) in parallel mode; `autofix=True` applies fixes inside the workers and produces byte-identical output (all scenarios yield identical diffs). Since the hook runs through pre-commit, which provides the concurrency, fixit's internal pool is now always disabled.

Changes:

* `fixit_paths` is always called with `parallel=False`: the concurrency comes from pre-commit chunked invocations or from the per-module pool below; a nested pool per module only pays spawn+import overhead.
* **Standalone CLI runs process the modules with a pool** (`run()` parallelizes its per-module loop when `PRE_COMMIT` is not in the environment and more than one module was collected): a real project with ~85 modules went from ~74s to ~19s (3.9x) with identical output. pre-commit exports `PRE_COMMIT=1` to its hooks, so under pre-commit the loop stays serial and the chunked invocations keep providing the concurrency.
* `utils.top_path` no longer spawns a `git rev-parse --show-toplevel` subprocess per directory (a py-spy profile showed those spawns as a significant slice of standalone runs); it walks up looking for the `.git` entry instead, caching results and reusing them by path prefix for children paths. `utils.walk_up` gets the same caching treatment (also caching the parent directory where a filename was already found, so sibling/children paths reuse it directly) and drops `lru_cache` since it was thrashing on projects with more directories than `maxsize=256`. Port of the same optimization applied to pylint-odoo in https://github.com/OCA/pylint-odoo/pull/579.
* New `--no-expand-manifest` CLI flag resolving the old TODO in `_get_changed`: under pre-commit, a chunk containing only `__manifest__.py` no longer re-scans the whole module (which duplicated work already being done by other concurrent chunks and could autofix files not part of the commit). The legacy CLI semantics (manifest path means the whole module, dating back to the original 2022 hook design where only manifests matched the hook `files` pattern, see #11) stay the default, so existing CLI usage and the test suite are unaffected. The `.pre-commit-hooks.yaml` entry passes the flag.
* `.coveragerc` forces `core = ctrace`: coverage>=7.10 defaults to `core=sysmon` on Python 3.14+, which does not support the dynamic contexts used by `--cov-context=test` and its CoverageWarning became an error under `filterwarnings = error`, breaking the py314/py315-dev jobs. Same fix as https://github.com/Vauxoo/pre-commit-vauxoo/pull/249
* tests: `test_checks.py` and `test_checks_po.py` accessed package submodules as attributes without importing them, relying on import side effects of other test modules; with current unpinned dependency versions the whole suite failed collection. Import them explicitly.

Verified with the full test suite (115 passed, 7 skipped), `tox -e lint`, end-to-end `pre-commit try-repo` runs exercising the hook entry, and byte-identical lint output on a real ~85-module project across all configurations.
