### PR TITLE
[REM] xml-template-prettier-incompatible: Remove check

### DIFF
--- a/README.md
+++ b/README.md
@@ -249,9 +249,6 @@ Dangerous qweb view defined with low priority
 * Check xml-duplicate-template-id
 Triggered when two templates share the same ID
 
-* Check xml-template-prettier-incompatible
-Indentify nodes incompatible with Prettier XML auto-fix generating possible unexpected text insertion
-
 * Check xml-xpath-translatable-item check `xpath` nodes using `contains(text(), 'Text translatable')`
 Since that the text could be translated so it is a mutable value.
 It could raise `ValueError` exception if the language is changed.
@@ -454,7 +451,7 @@ options:
  * xml-deprecated-qweb-directive
 
     - https://github.com/OCA/odoo-pre-commit-hooks/blob/v0.2.25/test_repo/test_module/website_templates.xml#L7 Deprecated QWeb directive `t-esc-options`. Use `t-options` instead
-    - https://github.com/OCA/odoo-pre-commit-hooks/blob/v0.2.25/test_repo/test_module/website_templates.xml#L42 Deprecated QWeb directive `t-field-options`. Use `t-options` instead
+    - https://github.com/OCA/odoo-pre-commit-hooks/blob/v0.2.25/test_repo/test_module/website_templates.xml#L26 Deprecated QWeb directive `t-field-options`. Use `t-options` instead
 
  * xml-deprecated-qweb-directive-15
 
@@ -509,14 +506,14 @@ options:
 
  * xml-not-valid-char-link
 
-    - https://github.com/OCA/odoo-pre-commit-hooks/blob/v0.2.25/test_repo/test_module/website_templates.xml#L64 The resource in in src/href contains a not valid character
-    - https://github.com/OCA/odoo-pre-commit-hooks/blob/v0.2.25/test_repo/test_module/website_templates.xml#L66 The resource in in src/href contains a not valid character
+    - https://github.com/OCA/odoo-pre-commit-hooks/blob/v0.2.25/test_repo/test_module/website_templates.xml#L48 The resource in in src/href contains a not valid character
+    - https://github.com/OCA/odoo-pre-commit-hooks/blob/v0.2.25/test_repo/test_module/website_templates.xml#L50 The resource in in src/href contains a not valid character
 
  * xml-oe-structure-missing-id
 
     - https://github.com/OCA/odoo-pre-commit-hooks/blob/v0.2.25/test_repo/test_module/website_templates.xml#L9 Consider removing the class `oe_structure` or adding a proper id to the tag. The id must contain `oe_structure`
     - https://github.com/OCA/odoo-pre-commit-hooks/blob/v0.2.25/test_repo/test_module/website_templates.xml#L13 Consider removing the class `oe_structure` or adding a proper id to the tag. The id must contain `oe_structure`
-    - https://github.com/OCA/odoo-pre-commit-hooks/blob/v0.2.25/test_repo/test_module/website_templates.xml#L46 Consider removing the class `oe_structure` or adding a proper id to the tag. The id must contain `oe_structure`
+    - https://github.com/OCA/odoo-pre-commit-hooks/blob/v0.2.25/test_repo/test_module/website_templates.xml#L30 Consider removing the class `oe_structure` or adding a proper id to the tag. The id must contain `oe_structure`
 
  * xml-record-missing-id
 
@@ -539,12 +536,6 @@ options:
     - https://github.com/OCA/odoo-pre-commit-hooks/blob/v0.2.25/test_repo/broken_module/deprecated_disable.xml#L4 The expected attributes order is `<record id="duplicate_record" ...>` Use `<record id="duplicate_record" ...>` instead
     - https://github.com/OCA/odoo-pre-commit-hooks/blob/v0.2.25/test_repo/broken_module/model_view_odoo2.xml#L43 The expected attributes order is `<record id="view_ir_config_search" ...>` Use `<record id="view_ir_config_search" ...>` instead
     - https://github.com/OCA/odoo-pre-commit-hooks/blob/v0.2.25/test_repo/broken_module/model_view_odoo2.xml#L68 The expected attributes order is `<record id="access_rule" ...>` Use `<record id="access_rule" ...>` instead
-
- * xml-template-prettier-incompatible
-
-    - https://github.com/OCA/odoo-pre-commit-hooks/blob/v0.2.25/test_repo/test_module/website_templates.xml#L22 Node `<textarea ...><t t-out=...` incompatible for Prettier XML auto-fix. To prevent unexpected text insertion prefer `<textarea t-out=...`
-    - https://github.com/OCA/odoo-pre-commit-hooks/blob/v0.2.25/test_repo/test_module/website_templates.xml#L24 Node `<textarea ...><t t-out=...` incompatible for Prettier XML auto-fix. To prevent unexpected text insertion prefer `<textarea t-out=...`
-    - https://github.com/OCA/odoo-pre-commit-hooks/blob/v0.2.25/test_repo/test_module/website_templates.xml#L26 Node `<textarea ...><t t-out=...` incompatible for Prettier XML auto-fix. To prevent unexpected text insertion prefer `<textarea t-out=...`
 
  * xml-view-dangerous-replace-low-priority
 

--- a/src/oca_pre_commit_hooks/checks_odoo_module_xml.py
+++ b/src/oca_pre_commit_hooks/checks_odoo_module_xml.py
@@ -611,36 +611,9 @@ class ChecksOdooModuleXML(BaseChecker):
 
         return f"{manifest_data['data_section']}/{template_id}_noupdate_{template.getparent().get('noupdate', '0')}"
 
-    def verify_template_prettier_incompatible(self, template, manifest_data):
-        """There are text tags incompatible with prettier xml autofix
-        More info https://github.com/OCA/odoo-pre-commit-hooks/issues/149"""
-        target_attrs = {"t-out", "t-esc", "t-raw"}
-        for node_textarea in template.xpath(".//textarea"):
-            if len(node_textarea_child := node_textarea.getchildren()) != 1:
-                continue
-            node_textarea_child = node_textarea_child[0]
-            has_text = node_textarea.text and node_textarea.text.strip()
-            has_tail = node_textarea_child.tail and node_textarea_child.tail.strip()
-            found_attr = set(node_textarea_child.attrib) & target_attrs
-            if node_textarea_child.tag != "t" or has_text or has_tail or not found_attr:
-                continue
-            found_attr = found_attr.pop()
-            self.register_error(
-                code="xml-template-prettier-incompatible",
-                message=(
-                    f"Node `<{node_textarea.tag} ...><{node_textarea_child.tag} {found_attr}=...` "
-                    "incompatible for Prettier XML auto-fix. To prevent unexpected text insertion "
-                    f"prefer `<{node_textarea.tag} {found_attr}=...`"
-                ),
-                filepath=manifest_data["filename_short"],
-                line=node_textarea_child.sourceline,
-            )
-            # TODO: Autofix using the same node
-
     @utils.only_required_for_checks(
         "xml-dangerous-qweb-replace-low-priority",
         "xml-duplicate-template-id",
-        "xml-template-prettier-incompatible",
     )
     def check_xml_templates(self):
         """* Check xml-dangerous-qweb-replace-low-priority
@@ -648,9 +621,6 @@ class ChecksOdooModuleXML(BaseChecker):
 
         * Check xml-duplicate-template-id
         Triggered when two templates share the same ID
-
-        * Check xml-template-prettier-incompatible
-        Indentify nodes incompatible with Prettier XML auto-fix generating possible unexpected text insertion
         """
         template_ids: Dict[str, List[FileElementPair]] = defaultdict(list)
         for manifest_data in self.manifest_datas:
@@ -665,11 +635,6 @@ class ChecksOdooModuleXML(BaseChecker):
                     if not template_id:  # pragma: no cover
                         continue
                     template_ids[template_id].append(FileElementPair(manifest_data["filename_short"], template))
-                if self.is_message_enabled(
-                    "xml-template-prettier-incompatible",
-                    manifest_data["disabled_checks"],
-                ):
-                    self.verify_template_prettier_incompatible(template, manifest_data)
 
         for xmlid_key, records in template_ids.items():
             if len(records) < 2:

--- a/test_repo/test_module/website_templates.xml
+++ b/test_repo/test_module/website_templates.xml
@@ -12,22 +12,6 @@
         <div class="oe_structure_gotcha"/>
         <main class="oe_structure oe_hello"/>
         <div class="d-flex fake_oe_structure"/>
-        <!--prettier incompatible-->
-        <textarea
-            name="text_area_name"
-            class="form-control mt-3"
-            required="required"
-            rows="4"
-            placeholder="help of the text area."
-        ><t t-out="model and model.field" /></textarea>
-        <!--prettier incompatible-->
-        <textarea name="description"><t t-out="campaign.description" /></textarea>
-        <!--prettier incompatible-->
-        <textarea name="conditional">  <t t-if="cond" t-out="val" /> </textarea>
-        <!--prettier compatible-->
-        <textarea name="fixed" t-out="campaign.description" />
-        <!--prettier compatible-->
-        <textarea name="mixed">   Ver: <t t-out="campaign.url" /></textarea>
         <li>text<strong
                 t-out="o.name"
                 t-options="{&quot;widget&quot;: &quot;float&quot;, &quot;precision&quot;: 2}"

--- a/tests/test_checks.py
+++ b/tests/test_checks.py
@@ -55,7 +55,6 @@ EXPECTED_ERRORS = {
     "xml-not-valid-char-link": 2,
     "xml-redundant-module-name": 3,
     "xml-syntax-error": 2,
-    "xml-template-prettier-incompatible": 3,
     "xml-view-dangerous-replace-low-priority": 7,
     "xml-xpath-translatable-item": 4,
     "xml-oe-structure-missing-id": 6,


### PR DESCRIPTION
Removes the `xml-template-prettier-incompatible` check added in #150.

### Why

- There are too many tag variants able to inject a **real newline** instead of being just a style change made by prettier, so the check only covers a small subset (`<textarea><t t-out=.../></textarea>`) and can not be made reliable without a lot of false negatives/positives.
- It also avoids having to change `xmlWhitespaceSensitivity: "strict"` in `.prettierrc.yml`, which is kept as is in order to prevent unexpected text insertion errors in production.

### Changes

- `checks_odoo_module_xml.py`: drop `verify_template_prettier_incompatible()`, its entry in `@utils.only_required_for_checks` and the call from `check_xml_templates()`
- `test_repo/test_module/website_templates.xml`: drop the `<textarea>` fixtures
- `tests/test_checks.py`: drop the expected errors entry
- `README.md`: regenerated with `tox -e update-readme`

Related to https://github.com/OCA/odoo-pre-commit-hooks/issues/149