### PR TITLE
[ADD] xml-view-missing-active: require the active field in ir.ui.view records

### DIFF
--- a/README.md
+++ b/README.md
@@ -220,6 +220,14 @@ This context avoid send email and mail log warning
 * Check xml-deprecated-tree-attribute
   The tree-view declaration is using a deprecated attribute.
 
+* Check xml-view-missing-active in ir.ui.view
+  The view record does not declare the `active` field. It defaults to True, but only a
+  declared field is written on a module update, so a view left disabled at the end of a
+  migration is never re-enabled. Declare it explicitly:
+
+    <record id="my_view" model="ir.ui.view">
+        <field name="active" eval="True" />
+
 * Check xml-record-missing-id
 Generated when a <record> tag has no id.
 
@@ -391,8 +399,8 @@ options:
 
  * manifest-superfluous-key
 
-    - https://github.com/OCA/odoo-pre-commit-hooks/blob/v0.2.26/test_repo/broken_module/__openerp__.py#L32 Delete empty values. You can disable this check by adding the following comment to the affected line or just above it `# lint-ignore=manifest-superfluous-key` or `# lint-ignore`
-    - https://github.com/OCA/odoo-pre-commit-hooks/blob/v0.2.26/test_repo/broken_module/__openerp__.py#L34 Delete empty values. You can disable this check by adding the following comment to the affected line or just above it `# lint-ignore=manifest-superfluous-key` or `# lint-ignore`
+    - https://github.com/OCA/odoo-pre-commit-hooks/blob/v0.2.26/test_repo/broken_module/__openerp__.py#L33 Delete empty values. You can disable this check by adding the following comment to the affected line or just above it `# lint-ignore=manifest-superfluous-key` or `# lint-ignore`
+    - https://github.com/OCA/odoo-pre-commit-hooks/blob/v0.2.26/test_repo/broken_module/__openerp__.py#L35 Delete empty values. You can disable this check by adding the following comment to the affected line or just above it `# lint-ignore=manifest-superfluous-key` or `# lint-ignore`
     - https://github.com/OCA/odoo-pre-commit-hooks/blob/v0.2.26/test_repo/woversion_module/__manifest__.py#L8 Delete empty values. You can disable this check by adding the following comment to the affected line or just above it `# lint-ignore=manifest-superfluous-key` or `# lint-ignore`
 
  * manifest-syntax-error
@@ -542,6 +550,12 @@ options:
     - https://github.com/OCA/odoo-pre-commit-hooks/blob/v0.2.26/test_repo/broken_module/model_view2.xml#L25 Dangerous use of `replace` from view with priority 0 < 99 Only replace as a last resort. Try `position="attributes"`, `position="move"` or `invisible="1"` first
     - https://github.com/OCA/odoo-pre-commit-hooks/blob/v0.2.26/test_repo/broken_module/model_view2.xml#L37 Dangerous use of `replace` from view with priority 0 < 99 Only replace as a last resort. Try `position="attributes"`, `position="move"` or `invisible="1"` first
     - https://github.com/OCA/odoo-pre-commit-hooks/blob/v0.2.26/test_repo/broken_module/model_view2.xml#L47 Dangerous use of `replace` from view with priority 0 < 99 Only replace as a last resort. Try `position="attributes"`, `position="move"` or `invisible="1"` first
+
+ * xml-view-missing-active
+
+    - https://github.com/OCA/odoo-pre-commit-hooks/blob/v0.2.26/test_repo/broken_module/demo/duplicated_id_demo.xml#L5 Missing `<field name="active" ...>` in the `ir.ui.view` record Use `<field name="active" eval="True" />`. It is the default value, but only a declared field is written on a module update, so a view left disabled at the end of a migration is never re-enabled without it
+    - https://github.com/OCA/odoo-pre-commit-hooks/blob/v0.2.26/test_repo/broken_module/model_view.xml#L5 Missing `<field name="active" ...>` in the `ir.ui.view` record Use `<field name="active" eval="True" />`. It is the default value, but only a declared field is written on a module update, so a view left disabled at the end of a migration is never re-enabled without it
+    - https://github.com/OCA/odoo-pre-commit-hooks/blob/v0.2.26/test_repo/broken_module/model_view2.xml#L5 Missing `<field name="active" ...>` in the `ir.ui.view` record Use `<field name="active" eval="True" />`. It is the default value, but only a declared field is written on a module update, so a view left disabled at the end of a migration is never re-enabled without it
 
  * xml-xpath-translatable-item
 

--- a/src/oca_pre_commit_hooks/checks_odoo_module_xml.py
+++ b/src/oca_pre_commit_hooks/checks_odoo_module_xml.py
@@ -43,6 +43,8 @@ class ChecksOdooModuleXML(BaseChecker):
     xpath_view_replaces = etree.XPath(".//*[@position='replace'][1]")
     xpath_char_links = etree.XPath(".//link[@href]|.//script[@src]")
     xpath_view_priority = etree.XPath("field[@name='priority'][1]")
+    xpath_view_active = etree.XPath("field[@name='active'][1]")
+    xpath_view_arch = etree.XPath("field[@name='arch' or @name='arch_base'][1]")
     xpath_field_name = etree.XPath("field[@name='name'][1]")
     xpath_record_fields_wname = etree.XPath("field[@name]")
     xpath_comment = etree.XPath("//comment()")
@@ -320,6 +322,12 @@ class ChecksOdooModuleXML(BaseChecker):
                 extra_positions=[(field[0]["filename_short"], field[1].sourceline) for field in fields[1:]],
             )
 
+        # view_missing_active, deferred to the end so the inserted lines do not move byte
+        # offsets under the checks that share this pass
+        if self.autofix:
+            for manifest_data in self.manifest_datas:
+                self._flush_view_missing_active(manifest_data)
+
     @utils.only_required_for_checks("xml-syntax-error")
     def check_xml_syntax_error(self):
         """* Check xml-syntax-error
@@ -511,7 +519,152 @@ class ChecksOdooModuleXML(BaseChecker):
             utils.perform_fix(manifest_data["filename"], content)
             self.update_node(manifest_data)
 
-    @utils.only_required_for_checks("xml-view-dangerous-replace-low-priority", "xml-deprecated-tree-attribute")
+    # convert.py's own DATA_ROOTS: all three map to `_tag_root`, which recurses, and any of
+    # them may be the document root.
+    DATA_ROOTS = ("odoo", "openerp", "data")
+
+    @classmethod
+    def _record_noupdate(cls, record):
+        """Effective `noupdate` of `record`, or `None` when `convert.py` would not load it.
+
+        Mirrors the parser: every ancestor up to the root must be a data container, otherwise
+        the record is markup inside a `<template>` body or inside another record's `arch` and is
+        never dispatched. The flag is read with `nodeattr2bool` semantics -- absent or empty
+        inherits the enclosing value, and anything other than `0`/`false`/`off` is true.
+        """
+        chain = []
+        node = record.getparent()
+        while node is not None:
+            if node.tag not in cls.DATA_ROOTS:
+                return None
+            chain.append(node)
+            node = node.getparent()
+        if not chain:
+            return None
+        noupdate = False
+        for node in reversed(chain):
+            value = (node.get("noupdate") or "").strip()
+            if value:
+                noupdate = value.lower() not in ("0", "false", "off")
+        return noupdate
+
+    def _is_loadable_view_record(self, record):
+        """Whether `convert.py` would load this record, and whether declaring `active` helps.
+
+        Disqualifying, in order:
+
+        * The record is not reachable as a record -- some ancestor is not a data container, so
+          it is markup inside a `<template>` body or inside another record's `arch`, and writing
+          a field into it would corrupt the arch.
+        * It is under an effective `noupdate="1"`, where `_tag_record` returns before reading a
+          single field once the record exists, so nothing is ever re-asserted.
+        * It has no xmlid. Such a record cannot be referenced or re-asserted by a later update;
+          `xml-record-missing-id` is the check with something to say about it.
+        * Its xmlid names another module, as in `<record id="account.portal_my_invoices">`. That
+          is an overwrite of a view someone else defines, and the declaration belongs to that
+          definition rather than to every module that touches it -- otherwise each of them
+          re-activates a foreign view on every update, overriding a deliberate archive. A prefix
+          naming the *current* module is only redundant, not an overwrite
+          (`xml-redundant-module-name` reports that), so those are still checked.
+        * It carries no `arch` of its own, so it only sets a few fields on a view defined
+          elsewhere, usually a core `<template>`.
+        """
+        if self._record_noupdate(record) is not False:
+            return False
+        record_id = record.get("id") or ""
+        if not record_id:
+            return False
+        if "." in record_id and record_id.split(".", 1)[0] != self.module_name:
+            return False
+        return bool(self.xpath_view_arch(record))
+
+    def _check_xml_view_missing_active(self, manifest_data, record):
+        """Report an `ir.ui.view` record that does not declare the `active` field.
+
+        `active` defaults to `True`, so leaving it out looks harmless, but the default only
+        applies when the record is created. `odoo/tools/convert.py` builds the values to write
+        from `rec.iterchildren("field")` -- the fields the record declares, and nothing else --
+        so on a module update an undeclared `active` is never written and the column keeps
+        whatever is in the database.
+
+        That matters because the Odoo Upgrade service disables views it cannot validate. It
+        re-enables the ones that validate again by the end of the run, but a view still failing
+        when the run ends stays disabled, and once the database is delivered nothing re-enables
+        it -- not even repairing its anchor afterwards. The page still renders, no error reaches
+        the log, and whatever the view contributed is missing from the screen. With `active`
+        declared, the next module update re-asserts it.
+
+        This applies to inherited views too. An inherited view does not edit its parent, it is a
+        record of its own with its own `active` column, and the value is not taken from the
+        parent.
+        """
+        if not self._is_loadable_view_record(record) or self.xpath_view_active(record):
+            return
+        self.register_error(
+            code="xml-view-missing-active",
+            message='Missing `<field name="active" ...>` in the `ir.ui.view` record',
+            info=(
+                'Use `<field name="active" eval="True" />`. It is the default value, but only a '
+                "declared field is written on a module update, so a view left disabled at the end "
+                "of a migration is never re-enabled without it"
+            ),
+            filepath=manifest_data["filename_short"],
+            line=record.sourceline,
+        )
+        if self.autofix:
+            # Deferred on purpose. Inserting a line here would move every byte offset after it,
+            # and the checks still to run in this pass hold offsets from before the insertion --
+            # re-parsing mid-iteration is what silently stops the other autofixes from applying.
+            manifest_data["_needs_active_fix"] = True
+
+    def _flush_view_missing_active(self, manifest_data):
+        """Insert every missing `<field name="active" eval="True" />` of a file, in one pass.
+
+        Runs after the record loop is over, and recomputes the positions from a fresh read, so
+        it is correct whatever the other autofixes did to the file earlier in the same run. The
+        insertions are applied from the bottom up, which keeps the offsets above each one valid.
+
+        The new line goes above the record's `arch` and copies its indentation, which puts
+        `active` after `name`/`model`/`inherit_id` and before the long block. A record whose
+        `arch` shares its line with something else is left alone: guessing the layout there
+        would do more harm than the fix is worth, so those stay reported and unfixed.
+        """
+        if not manifest_data.pop("_needs_active_fix", False):
+            return
+        node = self.update_node(manifest_data)
+        locator = self._get_tag_locator(manifest_data)
+        content = locator.content
+        # Follow the file's own line ending so a CRLF file does not end up with one lone LF.
+        eol = b"\r\n" if content.count(b"\r\n") > content.count(b"\n") - content.count(b"\r\n") else b"\n"
+        insertions = []
+        for record in node.iter("record"):
+            if record.get("model") != "ir.ui.view" or self.xpath_view_active(record):
+                continue
+            if not self._is_loadable_view_record(record):
+                continue
+            anchor = self.xpath_view_arch(record)[0]
+            tag_info = locator.get_tag(anchor)
+            if not tag_info:
+                continue
+            line_start = content.rfind(b"\n", 0, tag_info.start) + 1
+            indent = content[line_start : tag_info.start]
+            if indent.strip():
+                continue
+            insertions.append((line_start, indent))
+        if not insertions:
+            return
+        for line_start, indent in sorted(insertions, reverse=True):
+            content = (
+                content[:line_start] + indent + b'<field name="active" eval="True" />' + eol + content[line_start:]
+            )
+        utils.perform_fix(manifest_data["filename"], content)
+        self.update_node(manifest_data)
+
+    @utils.only_required_for_checks(
+        "xml-view-dangerous-replace-low-priority",
+        "xml-deprecated-tree-attribute",
+        "xml-view-missing-active",
+    )
     def visit_xml_record_view(self, manifest_data, record):
         """* Check xml-view-dangerous-replace-low-priority in ir.ui.view
 
@@ -521,9 +674,21 @@ class ChecksOdooModuleXML(BaseChecker):
 
         * Check xml-deprecated-tree-attribute
           The tree-view declaration is using a deprecated attribute.
+
+        * Check xml-view-missing-active in ir.ui.view
+          The view record does not declare the `active` field. It defaults to True, but only a
+          declared field is written on a module update, so a view left disabled at the end of a
+          migration is never re-enabled. Declare it explicitly:
+
+            <record id="my_view" model="ir.ui.view">
+                <field name="active" eval="True" />
         """
         if record.get("model") != "ir.ui.view":
             return
+
+        # view_missing_active
+        if self.is_message_enabled("xml-view-missing-active", manifest_data["disabled_checks"]):
+            self._check_xml_view_missing_active(manifest_data, record)
         # view_dangerous_replace_low_priority
         if self.is_message_enabled("xml-view-dangerous-replace-low-priority", manifest_data["disabled_checks"]):
             priority = self._get_priority(record)

--- a/test_repo/broken_module/__openerp__.py
+++ b/test_repo/broken_module/__openerp__.py
@@ -16,6 +16,7 @@
     },
     'data': [
         'model_view.xml', 'model_view2.xml', 'model_view_odoo.xml',
+        'view_active_edge_cases.xml',
         'model_view_odoo2.xml',
         'deprecated_disable.xml',
         'file_no_exist.xml',

--- a/test_repo/broken_module/view_active_edge_cases.xml
+++ b/test_repo/broken_module/view_active_edge_cases.xml
@@ -1,0 +1,55 @@
+<?xml version="1.0" encoding="UTF-8" ?>
+<odoo>
+    <data>
+        <!-- nested <data>: convert.py recurses through every DATA_ROOT, so this one is
+             loaded and must be both reported and fixed -->
+        <data>
+            <record id="view_nested_data" model="ir.ui.view">
+                <field name="name">nested.data</field>
+                <field name="arch" type="xml">
+                    <form />
+                </field>
+            </record>
+        </data>
+
+        <!-- arch_base is a view too -->
+        <record id="view_arch_base" model="ir.ui.view">
+            <field name="name">arch.base</field>
+            <field name="arch_base" type="xml">
+                <form />
+            </field>
+        </record>
+
+        <!-- nodeattr2bool: anything that is not 0/false/off is true, so this is noupdate -->
+        <data noupdate="on">
+            <record id="view_noupdate_on" model="ir.ui.view">
+                <field name="name">noupdate.on</field>
+                <field name="arch" type="xml">
+                    <form />
+                </field>
+            </record>
+        </data>
+
+        <!-- an empty noupdate inherits the enclosing one instead of resetting it -->
+        <data noupdate="1">
+            <data noupdate="">
+                <record id="view_noupdate_inherited" model="ir.ui.view">
+                    <field name="name">noupdate.inherited</field>
+                    <field name="arch" type="xml">
+                        <form />
+                    </field>
+                </record>
+            </data>
+
+            <!-- an explicit 0 does reset it, so this one is reported -->
+            <data noupdate="0">
+                <record id="view_noupdate_reset" model="ir.ui.view">
+                    <field name="name">noupdate.reset</field>
+                    <field name="arch" type="xml">
+                        <form />
+                    </field>
+                </record>
+            </data>
+        </data>
+    </data>
+</odoo>

--- a/tests/test_checks.py
+++ b/tests/test_checks.py
@@ -45,7 +45,7 @@ EXPECTED_ERRORS = {
     "weblate-component-too-long": 1,
     "xml-create-user-wo-reset-password": 1,
     "xml-dangerous-qweb-replace-low-priority": 9,
-    "xml-deprecated-data-node": 8,
+    "xml-deprecated-data-node": 9,
     "xml-deprecated-openerp-node": 4,
     "xml-deprecated-qweb-directive-15": 4,
     "xml-deprecated-qweb-directive": 2,
@@ -56,6 +56,7 @@ EXPECTED_ERRORS = {
     "xml-redundant-module-name": 3,
     "xml-syntax-error": 2,
     "xml-view-dangerous-replace-low-priority": 7,
+    "xml-view-missing-active": 28,
     "xml-xpath-translatable-item": 4,
     "xml-oe-structure-missing-id": 6,
     "xml-record-missing-id": 2,
@@ -218,6 +219,16 @@ class TestChecks(common.ChecksCommon):
         assert b'<field name="amount">1.08</field>' in content, "The XML eval was previously fixed"
         assert b'<field name="phone">4777777777</field>' in content, "The XML eval was previously fixed"
         assert b'<field name="priority">-1</field>' in content, "The XML eval was not fixed"
+
+        fname_view_edge = os.path.join(self.test_repo_path, "broken_module", "view_active_edge_cases.xml")
+        with open(fname_view_edge, "rb") as f_view_edge:
+            content = f_view_edge.read()
+        assert b'name="active"' not in content, "The active field was previously added"
+
+        fname_view_wo_active = os.path.join(self.test_repo_path, "broken_module", "model_view.xml")
+        with open(fname_view_wo_active, "rb") as f_view_wo_active:
+            content = f_view_wo_active.read()
+        assert b'name="active"' not in content, "The active field was previously added"
 
         fname_redundant_module_name = os.path.join(self.test_repo_path, "broken_module", "model_view2.xml")
         with open(fname_redundant_module_name, "rb") as f_redundant_module_name:
@@ -407,6 +418,46 @@ class TestChecks(common.ChecksCommon):
         # comments contain 1 valid deprecated
         assert content.count(b"t-esc") == 1, "The deprecated t-esc was not fixed"
         assert content.count(b"t-raw") == 1, "The deprecated t-esc was not fixed"
+
+        # xml-view-missing-active: inserted above the record's own arch, carrying the
+        # indentation of the line it is inserted above
+        with open(fname_view_wo_active, "rb") as f_view_wo_active:
+            content_active = f_view_wo_active.read()
+        assert (
+            b'            <field name="active" eval="True" />\n'
+            b'            <field name="arch" type="xml">' in content_active
+        ), "The active field was not inserted above the arch"
+        # the two records without any field carry no arch of their own, so they are neither
+        # reported nor fixed
+        assert content_active.count(b'name="active"') == 1, "Only the record carrying an arch must be fixed"
+
+        # The insertion is deferred to the end of the record loop precisely so that it does not
+        # move the byte offsets the other autofixes of the same pass are holding. This is the
+        # regression guard: an immediate insertion made these stop applying.
+        with open(fname_wrong_xml_eval, "rb") as f_wrong_xml_eval:
+            content_eval = f_wrong_xml_eval.read()
+        assert b'<field name="sequence" eval="1" />' in content_eval, "The eval fix stopped applying"
+        assert b'<field name="priority" eval="-1" />' in content_eval, "The eval fix stopped applying"
+
+        # The loadability guard must agree between the side that reports and the side that
+        # fixes, or a record is reported on every run and never fixed. The nested <data> is the
+        # case that used to fall in that gap.
+        with open(fname_view_edge, "rb") as f_view_edge:
+            content_edge = f_view_edge.read()
+        assert content_edge.count(b'name="active"') == 3, "The reported records were not all fixed"
+        for xmlid in (b"view_nested_data", b"view_arch_base", b"view_noupdate_reset"):
+            assert xmlid in content_edge, "The fixture lost a record"
+        # ... and the ones under an effective noupdate are neither reported nor touched, since
+        # `_tag_record` never writes a field there
+        head_on = content_edge.split(b'id="view_noupdate_on"')[1].split(b"</record>")[0]
+        assert b'name="active"' not in head_on, "A noupdate record must not be fixed"
+        head_inherited = content_edge.split(b'id="view_noupdate_inherited"')[1].split(b"</record>")[0]
+        assert b'name="active"' not in head_inherited, "An inherited noupdate must not be fixed"
+
+        # Running the fixer again must not insert the field twice
+        self.checks_run(self.file_paths, autofix=True, no_exit=True, no_verbose=False)
+        with open(fname_view_wo_active, "rb") as f_view_wo_active:
+            assert f_view_wo_active.read().count(b'name="active"') == 1, "The active field autofix is not idempotent"
 
     def test_xml_attributes_order_custom(self):
         custom_order = oca_pre_commit_hooks.global_parser.parse_xml_attributes_order("[class], [id], [t-if]")


### PR DESCRIPTION
## Why

`active` defaults to `True`, so leaving it out of a view record looks harmless. The default only applies when the record is **created**, though. On a module update the values to write are built from the fields the record declares, and nothing else — [`odoo/tools/convert.py#L393-L395`](https://github.com/odoo/odoo/blob/928ae2ba164022a51cdfe548dec9491c61339a5f/odoo/tools/convert.py#L393-L395):

```python
res = {}
...
for field in rec.iterchildren('field'):
```

So an undeclared `active` is never written, and the column keeps whatever the database holds.

That matters because the Odoo Upgrade service disables views it cannot validate. **It does re-enable most of them**: in one observed migration of a large customer project, 59 views were disabled and 44 came back before the run ended. What does not come back is a view still failing when the run ends — once the database is delivered nothing re-enables it, not even repairing its anchor afterwards. The page still renders, no error reaches the log, and whatever the view contributed is missing from the screen. That is how a default UTM campaign type and a set of configuration values silently disappeared and were noticed days later by chance.

With `active` declared, the next module update re-asserts it and the view recovers on its own.

**The flip side, stated plainly:** re-asserting `active=True` on every update also resurrects a view someone deliberately archived in the database, and where the arch is still broken it makes the update raise instead of staying quietly disabled. That is a deliberate trade — a loud failure over a silent loss.

## Inherited views are covered

An inherited view does not edit its parent. It is a record of its own with its own `active` column, and the value is not taken from the parent — [`ir_ui_view.py#L192-L201`](https://github.com/odoo/odoo/blob/928ae2ba164022a51cdfe548dec9491c61339a5f/odoo/addons/base/models/ir_ui_view.py#L192-L201) says so in the field's own help:

> If this view is inherited,
> * if True, the view always extends its parent
> * if False, the view currently does not extend its parent but can be enabled

In that migration, 55 of the 59 disabled views were inherited ones.

## One predicate, mirroring the parser

The side that reports and the side that fixes share a single loadability predicate, so a record can never be reported on every run and then refused by the fixer. It mirrors `convert.py` rather than approximating it:

- **Every ancestor up to the root must be one of `convert.py`'s `DATA_ROOTS`** (`odoo`, `openerp`, `data`). All three map to `_tag_root`, which recurses, and any of them may be the document root — so a record under a nested `<data>` is loaded and is checked, while one inside a `<template>` body or inside another record's `arch` is markup and is not.
- **`noupdate` is read with `nodeattr2bool` semantics** ([`convert.py#L211-L217`](https://github.com/odoo/odoo/blob/928ae2ba164022a51cdfe548dec9491c61339a5f/odoo/tools/convert.py#L211-L217)): absent or empty inherits the enclosing value, and anything other than `0`/`false`/`off` is true. So `noupdate="on"` is noupdate, and an explicit `noupdate="0"` inside a `"1"` resets it.

## What is deliberately left alone

Declaring `active` would not do what the message promises for these:

- **Records under an effective `noupdate="1"`.** [`convert.py#L360-L376`](https://github.com/odoo/odoo/blob/928ae2ba164022a51cdfe548dec9491c61339a5f/odoo/tools/convert.py#L360-L376) returns before reading a single field once the record exists there.
- **Records with no xmlid**, which cannot be referenced or re-asserted at all.
- **Records whose xmlid names another module**, as in `<record id="account.portal_my_invoices">`. That is an overwrite of a view someone else defines, and the declaration belongs to that definition rather than to every module that touches it. This one is policy rather than mechanics — those fields *are* written on update — but it keeps a custom module from re-activating a foreign view and overriding a deliberate archive. A prefix naming the *current* module is only redundant (`xml-redundant-module-name` reports that), so those are still checked.
- **Records with no `arch` or `arch_base` of their own.**

`<template>` is not covered either. [`convert.py#L517-L524`](https://github.com/odoo/odoo/blob/928ae2ba164022a51cdfe548dec9491c61339a5f/odoo/tools/convert.py#L517-L524) emits the `active` field only when the record is new:

```python
# If the "active" value is set on the root node (instead of an inner
# <field>), it is treated as the value for the "active" field but only
# when *not updating*. ...
if el.get('active') in ("True", "False"):
    view_id = self.id_get(tpl_id, raise_if_not_found=False)
    if self.mode != "update" or not view_id:
        record.append(Field(name='active', eval=el.get('active')))
```

Odoo's own comment on the field says qweb views *"will thus always require upgrade scripts if you really want to change the default value of their `active` field"*.

## Matching only direct children

The `active` of the record and the `active` of a list column look identical to a naive search:

```xml
<record id="view_users_tree" model="ir.ui.view">
    <field name="arch" type="xml">
        <xpath expr="//field[@name='lang']" position="before">
            <field name="active" />          <!-- a column, not the record's field -->
```

The check uses the same relative one-step XPath the module already uses for `priority`, so only direct children of the `<record>` match — which is also exactly the set `convert.py` writes.

## How noisy this is

Be aware before merging: **almost no existing code declares `active`.** Odoo core itself declares it in 11 of 3728 view records (0.3%), and a large customer project reports 636 of its 639. The hook has no default-disabled tier, so this turns CI red wherever it lands until the files are fixed — worth deciding deliberately rather than discovering.

## Autofix

Inserts `<field name="active" eval="True" />` immediately above the record's `arch`, copying that field's indentation and the file's line ending:

```diff
     <record id="my_report_search_view" model="ir.ui.view">
         <field name="name">my.report.search</field>
         <field name="model">my.report</field>
+        <field name="active" eval="True" />
         <field name="arch" type="xml">
```

It is **deferred** until the record loop is over and recomputes its positions from a fresh read. Inserting a line mid-pass moves every byte offset after it, and the checks that share the pass hold offsets from before the insertion — while the insertion was immediate, `xml-field-numeric-without-eval` silently stopped applying its own fix. Insertions are applied bottom-up so the offsets above each one stay valid.

A record whose `arch` shares its line with something else is reported but left alone rather than guessed at.

## Tests

`test_repo/broken_module/view_active_edge_cases.xml` pins the parts an error count alone would not catch:

| case | expected |
| --- | --- |
| record under a nested `<data>` | reported **and fixed** |
| `arch_base` instead of `arch` | reported |
| `noupdate="on"` | not reported |
| empty `noupdate` inside `noupdate="1"` | not reported |
| `noupdate="0"` inside `noupdate="1"` | reported |

`test_autofix` also asserts the insertion position and indentation, that every reported record in that file is actually fixed (the report/fix parity), that the other autofixes of the same pass still apply, and idempotency. Before these, the fix could have been a no-op and the suite would still have passed.

## Verification

- `tox -e py-multi` — **115 passed, 7 skipped**
- `tox -e lint`, `tox -e update-readme` — clean
- Run against a real project: 636 records reported, the autofix produces well-formed XML, and a second run reports nothing for the records it fixed.
